### PR TITLE
Add wait time after reload

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 
 ebusctl reload
+echo "reloading config, may take 8 seconds"
+sleep 8
+echo "should be ready now"
+read -n1 -r -p "Press any key to start" key
 
 echo "SoftwareVersion"
 ebusctl read -f SoftwareVersion


### PR DESCRIPTION
In some cases, (if the config file is in the encon dir) reloading the config takes up to 8 seconds, so I added some comments and a sleep after the relaod