### PR TITLE
Improved Translation and Parameter names

### DIFF
--- a/3c.renovent-excellent-300-english.csv
+++ b/3c.renovent-excellent-300-english.csv
@@ -5,31 +5,33 @@
 ## - Brink Service Tool (decompiled via Jetbrains DotPeak): https://www.brinkclimatesystems.nl/tools/software-brink-service-tool-en
 ## - Renovent 150 Datasheet: https://manuals.plus/brink/renovent-sky-150-plus-mechanical-ventilation-with-heat-recovery-manual
 ## - Modbus Module Datasheet: https://www.brinkclimatesystems.nl/documenten/modbus-uwa2-b-uwa2-e-installation-regulations-614882.pdf
-##
-## For ebusd-configuration files for complete portfolio of Brink HRU units go to https://github.com/pvyleta/ebusd-brink-hru
+## Message names are based on official Brink Service Tool translations with removed spaces and special characters. 
+## Message comment is the name of the parameter as used internally in code (as to help if the translation itself is confusing)
+## 
+## For ebusd configuration files for the complete Brink portfolio go to https://github.com/pvyleta/ebusd-brink-hru
 
 *r,Excellent300,,,,3c,
 *w,Excellent300,,,,3c,
 
 ## COMMON HRU COMMANDS ## (WTWCommands.cs - Some of them might not be applicable for this device, use with caution)
-w,,FactoryReset,,,,40ff,466163746f72795265736574
-w,,ResetNotifications,,,,4091,,,,UIR,0x0001=Errors;0x0100=Filter;0x0101=ErrorsAndFilter;0x0000=NoResetRequested,,NoResetRequested is a dummy message doing nothing. It might be useful for integration in MQTT and HA automation.
-r,,RequestErrorList,,,,4090,,,,HEX:18,,,
-w,,FanMode,,,,40a1,,,,ULR,0x0=Holiday;0x00010001=Reduced;0x00020002=Normal;0x00030003=High,,
-r,,FilterNotificationFlow,,,,4050,1c,,,UIR,-1000,m³,,Min,,UIR,-1000,m³,,Max,,UIR,-1000,m³,,Step,,UIR,-1000,m³,,Default,,UIR,-1000,m³,
-r,,TotalFilterDays,,,,4050,22,,,UIR,,Days,,Min,,UIR,,Days,,Max,,UIR,,Days,,Step,,UIR,,Days,,Default,,UIR,,Days,
-r,,TotalFilterFlow,,,,4050,23,,,UIR,-1000,m³,,Min,,UIR,-1000,m³,,Max,,UIR,-1000,m³,,Step,,UIR,-1000,m³,,Default,,UIR,-1000,m³,
-r,,TotalOperatingHours,,,,4050,24,,,UIR,-5,Hours,,Min,,UIR,-5,Hours,,Max,,UIR,-5,Hours,,Step,,UIR,-5,Hours,,Default,,UIR,-5,Hours,
-r,,TotalFlow,,,,4050,25,,,UIR,-1000,m³,,Min,,UIR,-1000,m³,,Max,,UIR,-1000,m³,,Step,,UIR,-1000,m³,,Default,,UIR,-1000,m³,
+w,,FactoryReset,FactoryReset,,,40ff,466163746f72795265736574
+w,,ResetNotifications,ResetNotifications,,,4091,,,,UIR,0x0001=Errors;0x0100=Filter;0x0101=ErrorsAndFilter;0x0000=NoResetRequested,,NoResetRequested is a dummy message doing nothing. It might be useful for integration in MQTT and HA automation.
+r,,ErrorHistory,RequestErrorList,,,4090,,,,HEX:18,,,
+w,,FanMode,FanMode,,,40a1,,,,ULR,0x0=Holiday;0x00010001=Reduced;0x00020002=Normal;0x00030003=High,,
+r,,FilterMaximumFlow,FilterNotificationFlow,,,4050,1c,,,UIR,-1000,m³,,Min,,UIR,-1000,m³,,Max,,UIR,-1000,m³,,Step,,UIR,-1000,m³,,Default,,UIR,-1000,m³,
+r,,FilterUsageDays,TotalFilterDays,,,4050,22,,,UIR,,Days,,Min,,UIR,,Days,,Max,,UIR,,Days,,Step,,UIR,,Days,,Default,,UIR,,Days,
+r,,FilterUsage,TotalFilterFlow,,,4050,23,,,UIR,-1000,m³,,Min,,UIR,-1000,m³,,Max,,UIR,-1000,m³,,Step,,UIR,-1000,m³,,Default,,UIR,-1000,m³,
+r,,OperatingTime,TotalOperatingHours,,,4050,24,,,UIR,-5,Hours,,Min,,UIR,-5,Hours,,Max,,UIR,-5,Hours,,Step,,UIR,-5,Hours,,Default,,UIR,-5,Hours,
+r,,TotalFlow1000m3,TotalFlow,,,4050,25,,,UIR,-1000,m³,,Min,,UIR,-1000,m³,,Max,,UIR,-1000,m³,,Step,,UIR,-1000,m³,,Default,,UIR,-1000,m³,
 
 ## Curent state and sensors ##
 r,,FanMode,FanMode,,,4022,01,,,UIR,0=Holiday;1=Reduced;2=Normal;3=High;4=Auto,,
-r,,SettingInletFlow,InletFlowSetting,,,4022,09,,,UIR,,m³/h,
-r,,SettingExhaustFlow,ExhaustFlowSetting,,,4022,0a,,,UIR,,m³/h,
-r,,InletFlow,ActualInletFlow,,,4022,0b,,,UIR,,m³/h,
-r,,ExhaustFlow,ActualExhaustFlow,,,4022,0c,,,UIR,,m³/h,
-r,,InletFanSpeed,ActualInletfanSpeed,,,4022,02,,,UIR,,rpm,
-r,,ExhaustFanSpeed,ActualExhaustfanSpeed,,,4022,03,,,UIR,,rpm,
+r,,InletFlowSetting,SettingInletFlow,,,4022,09,,,UIR,,m³/h,
+r,,ExhaustFlowSetting,SettingExhaustFlow,,,4022,0a,,,UIR,,m³/h,
+r,,ActualInletFlow,InletFlow,,,4022,0b,,,UIR,,m³/h,
+r,,ActualExhaustFlow,ExhaustFlow,,,4022,0c,,,UIR,,m³/h,
+r,,ActualInletfanSpeed,InletFanSpeed,,,4022,02,,,UIR,,rpm,
+r,,ActualExhaustfanSpeed,ExhaustFanSpeed,,,4022,03,,,UIR,,rpm,
 r,,PerilexPosition,PerilexPosition,,,4022,05,,,UIR,0=Position_0;1=Position_1;2=Position_2;3=Position_3;,,
 r,,SwitchPosition,SwitchPosition,,,4022,06,,,UIR,0=Position_0;1=Position_1;2=Position_2;3=Position_3;,,
 r,,Contact1Position,Contact1Position,,,4022,1b,,,UIR,0=Off;1=On,,
@@ -48,80 +50,80 @@ r,,FanStatus,FanStatus,,,4022,11,,,UIR,0=Initializing;1=ConstantFlow;2=ConstantP
 r,,InsideTemperature,InsideTemperature,,,4022,07,,,SIR,10,°C,
 r,,OutsideTemperature,OutsideTemperature,,,4022,08,,,SIR,10,°C,
 r,,OptionTemperature,OptionTemperature,,,4022,1a,,,SIR,10,°C,
-r,,FilterStatus,FilterNotification,,,4022,18,,,UIR,0=Clean;1=Dirty,,
+r,,FilterNotification,FilterStatus,,,4022,18,,,UIR,0=Clean;1=Dirty,,
 r,,RelativeHumidity,RelativeHumidity,,,4022,20,,,SIR,10,%,
 r,,HumidityBoostState,HumidityBoostState,,,4022,21,,,UIR,0=Error;1=NotInitialized;2=SensorNotActive;3=PowerUpDelay;4=NormalRH;5=BoostRising;6=BoostStable;7=BoostDecending;8=BoostRHLowLevelStable,Pa,
-r,,PressureInlet,ActualInletPressure,,,4022,14,,,UIR,10,Pa,
-r,,PressureExhaust,ActualExhaustPressure,,,4022,15,,,UIR,10,Pa,
-r,,EBusSyncGenErrorCount,EBusSyncGenErrors,,,4022,64,,,UIR,,,
+r,,ActualInletPressure,PressureInlet,,,4022,14,,,UIR,10,Pa,
+r,,ActualExhaustPressure,PressureExhaust,,,4022,15,,,UIR,10,Pa,
+r,,EBusSyncGenErrors,EBusSyncGenErrorCount,,,4022,64,,,UIR,,,
 r,,CO2Sensor1Status,CO2Sensor1Status,,,4022,28,,,UIR,0=Error;1=NotInitialized;2=Idle;3=WarmingUp;4=Running;5=Calibrating;6=SelfTest,,
-r,,CO2Sensor1Value,CO2Sensor1Value,,,4022,29,,,UIR,,ppm,
+r,,CO2Sensor1Level,CO2Sensor1Value,,,4022,29,,,UIR,,ppm,
 r,,CO2Sensor2Status,CO2Sensor2Status,,,4022,2a,,,UIR,0=Error;1=NotInitialized;2=Idle;3=WarmingUp;4=Running;5=Calibrating;6=SelfTest,,
-r,,CO2Sensor2Value,CO2Sensor2Value,,,4022,2b,,,UIR,,ppm,
+r,,CO2Sensor2Level,CO2Sensor2Value,,,4022,2b,,,UIR,,ppm,
 r,,CO2Sensor3Status,CO2Sensor3Status,,,4022,2c,,,UIR,0=Error;1=NotInitialized;2=Idle;3=WarmingUp;4=Running;5=Calibrating;6=SelfTest,,
-r,,CO2Sensor3Value,CO2Sensor3Value,,,4022,2d,,,UIR,,ppm,
+r,,CO2Sensor3Level,CO2Sensor3Value,,,4022,2d,,,UIR,,ppm,
 r,,CO2Sensor4Status,CO2Sensor4Status,,,4022,2e,,,UIR,0=Error;1=NotInitialized;2=Idle;3=WarmingUp;4=Running;5=Calibrating;6=SelfTest,,
-r,,CO2Sensor4Value,CO2Sensor4Value,,,4022,2f,,,UIR,,ppm,
+r,,CO2Sensor4Level,CO2Sensor4Value,,,4022,2f,,,UIR,,ppm,
 
-## Configuration parameters ##
-w,,FlowMode0,FlowMode0,,,4080,21,,,SIR,,m³/h,[min:0;max:50;step:50;default:50]
-r,,FlowMode0,FlowMode0,,,4050,21,,,SIR,,m³/h,,Min,,SIR,,m³/h,[min:0],Max,,SIR,,m³/h,[max:50],Step,,SIR,,m³/h,[step:50],Default,,SIR,,m³/h,[default:50]
-w,,FlowMode1,FlowMode1,,,4080,01,,,SIR,,m³/h,[min:50;max:300;step:5;default:100]
-r,,FlowMode1,FlowMode1,,,4050,01,,,SIR,,m³/h,,Min,,SIR,,m³/h,[min:50],Max,,SIR,,m³/h,[max:300],Step,,SIR,,m³/h,[step:5],Default,,SIR,,m³/h,[default:100]
-w,,FlowMode2,FlowMode2,,,4080,02,,,SIR,,m³/h,[min:50;max:300;step:5;default:150]
-r,,FlowMode2,FlowMode2,,,4050,02,,,SIR,,m³/h,,Min,,SIR,,m³/h,[min:50],Max,,SIR,,m³/h,[max:300],Step,,SIR,,m³/h,[step:5],Default,,SIR,,m³/h,[default:150]
-w,,FlowMode3,FlowMode3,,,4080,03,,,SIR,,m³/h,[min:50;max:300;step:5;default:225]
-r,,FlowMode3,FlowMode3,,,4050,03,,,SIR,,m³/h,,Min,,SIR,,m³/h,[min:50],Max,,SIR,,m³/h,[max:300],Step,,SIR,,m³/h,[step:5],Default,,SIR,,m³/h,[default:225]
-w,,BypassTemp,BypassTemp,,,4080,04,,,SIR,10,°C,[min:150;max:350;step:5;default:240]
-r,,BypassTemp,BypassTemp,,,4050,04,,,SIR,10,°C,,Min,,SIR,10,°C,[min:150],Max,,SIR,10,°C,[max:350],Step,,SIR,10,°C,[step:5],Default,,SIR,10,°C,[default:240]
-w,,BypassTempHyst,BypassTempHyst,,,4080,30,,,SIR,10,°C,[min:0;max:50;step:5;default:20]
-r,,BypassTempHyst,BypassTempHyst,,,4050,30,,,SIR,10,°C,,Min,,SIR,10,°C,[min:0],Max,,SIR,10,°C,[max:50],Step,,SIR,10,°C,[step:5],Default,,SIR,10,°C,[default:20]
-w,,BypassMode,BypassMode,,,4080,1b,,,UIR,0=Auto;1=Closed;2=Open,,[min:0;max:2;step:1;default:0]
-r,,BypassMode,BypassMode,,,4050,1b,,,UIR,0=Auto;1=Closed;2=Open,,,,,IGN:6,,,,Default,,UIR,0=Auto;1=Closed;2=Open,,[default:0] - min/max/step fields of enum message omitted
-w,,CVWTWMode,CVWTWMode,,,4080,07,,,UIR,0=off;1=on,,[min:0;max:1;step:1;default:0]
-r,,CVWTWMode,CVWTWMode,,,4050,07,,,UIR,0=off;1=on,,,,,IGN:6,,,,Default,,UIR,0=off;1=on,,[default:0] - min/max/step fields of enum message omitted
-w,,UnbalanceMode,UnbalanceMode,,,4080,08,,,UIR,0=Not Permitted;1=Permitted,,[min:0;max:1;step:1;default:1]
-r,,UnbalanceMode,UnbalanceMode,,,4050,08,,,UIR,0=Not Permitted;1=Permitted,,,,,IGN:6,,,,Default,,UIR,0=Not Permitted;1=Permitted,,[default:1] - min/max/step fields of enum message omitted
-w,,UnbalanceFlow,UnbalanceFlow,,,4080,09,,,SIR,,m³/h,[min:-100;max:100;step:1;default:0]
-r,,UnbalanceFlow,UnbalanceFlow,,,4050,09,,,SIR,,m³/h,,Min,,SIR,,m³/h,[min:-100],Max,,SIR,,m³/h,[max:100],Step,,SIR,,m³/h,[step:1],Default,,SIR,,m³/h,[default:0]
+## Configuration parameters ## (values in brackets next to field are definitions of those fields values from Brink Service Tool.)
+w,,AirFlowRateMode0,FlowMode0,,,4080,21,,,SIR,,m³/h,[min:0;max:50;step:50;default:50]
+r,,AirFlowRateMode0,FlowMode0,,,4050,21,,,SIR,,m³/h,,Min,,SIR,,m³/h,[min:0],Max,,SIR,,m³/h,[max:50],Step,,SIR,,m³/h,[step:50],Default,,SIR,,m³/h,[default:50]
+w,,AirFlowRateMode1,FlowMode1,,,4080,01,,,SIR,,m³/h,[min:50;max:300;step:5;default:100]
+r,,AirFlowRateMode1,FlowMode1,,,4050,01,,,SIR,,m³/h,,Min,,SIR,,m³/h,[min:50],Max,,SIR,,m³/h,[max:300],Step,,SIR,,m³/h,[step:5],Default,,SIR,,m³/h,[default:100]
+w,,AirFlowRateMode2,FlowMode2,,,4080,02,,,SIR,,m³/h,[min:50;max:300;step:5;default:150]
+r,,AirFlowRateMode2,FlowMode2,,,4050,02,,,SIR,,m³/h,,Min,,SIR,,m³/h,[min:50],Max,,SIR,,m³/h,[max:300],Step,,SIR,,m³/h,[step:5],Default,,SIR,,m³/h,[default:150]
+w,,AirFlowRateMode3,FlowMode3,,,4080,03,,,SIR,,m³/h,[min:50;max:300;step:5;default:225]
+r,,AirFlowRateMode3,FlowMode3,,,4050,03,,,SIR,,m³/h,,Min,,SIR,,m³/h,[min:50],Max,,SIR,,m³/h,[max:300],Step,,SIR,,m³/h,[step:5],Default,,SIR,,m³/h,[default:225]
+w,,BypassTemperature,BypassTemp,,,4080,04,,,SIR,10,°C,[min:150;max:350;step:5;default:240]
+r,,BypassTemperature,BypassTemp,,,4050,04,,,SIR,10,°C,,Min,,SIR,10,°C,[min:150],Max,,SIR,10,°C,[max:350],Step,,SIR,10,°C,[step:5],Default,,SIR,10,°C,[default:240]
+w,,BypassHysteresis,BypassTempHyst,,,4080,30,,,SIR,10,°C,[min:0;max:50;step:5;default:20]
+r,,BypassHysteresis,BypassTempHyst,,,4050,30,,,SIR,10,°C,,Min,,SIR,10,°C,[min:0],Max,,SIR,10,°C,[max:50],Step,,SIR,10,°C,[step:5],Default,,SIR,10,°C,[default:20]
+w,,OperationBypassValve,BypassMode,,,4080,1b,,,UIR,0=Auto;1=Closed;2=Open,,[min:0;max:2;step:1;default:0]
+r,,OperationBypassValve,BypassMode,,,4050,1b,,,UIR,0=Auto;1=Closed;2=Open,,,,,IGN:6,,,,Default,,UIR,0=Auto;1=Closed;2=Open,,[default:0] - min/max/step fields of enum message omitted
+w,,CentralHeatingHeatRecovery,CVWTWMode,,,4080,07,,,UIR,0=off;1=on,,[min:0;max:1;step:1;default:0]
+r,,CentralHeatingHeatRecovery,CVWTWMode,,,4050,07,,,UIR,0=off;1=on,,,,,IGN:6,,,,Default,,UIR,0=off;1=on,,[default:0] - min/max/step fields of enum message omitted
+w,,ImbalancePermissible,UnbalanceMode,,,4080,08,,,UIR,0=Not Permitted;1=Permitted,,[min:0;max:1;step:1;default:1]
+r,,ImbalancePermissible,UnbalanceMode,,,4050,08,,,UIR,0=Not Permitted;1=Permitted,,,,,IGN:6,,,,Default,,UIR,0=Not Permitted;1=Permitted,,[default:1] - min/max/step fields of enum message omitted
+w,,FixedImbalance,UnbalanceFlow,,,4080,09,,,SIR,,m³/h,[min:-100;max:100;step:1;default:0]
+r,,FixedImbalance,UnbalanceFlow,,,4050,09,,,SIR,,m³/h,,Min,,SIR,,m³/h,[min:-100],Max,,SIR,,m³/h,[max:100],Step,,SIR,,m³/h,[step:1],Default,,SIR,,m³/h,[default:0]
 w,,ExtraHeaterType,ExtraHeaterType,,,4080,0a,,,UIR,,,[min:0;max:2;step:1;default:0]
 r,,ExtraHeaterType,ExtraHeaterType,,,4050,0a,,,UIR,,,,Min,,UIR,,,[min:0],Max,,UIR,,,[max:2],Step,,UIR,,,[step:1],Default,,UIR,,,[default:0]
-w,,PostheaterTemp,PostheaterTemp,,,4080,0b,,,SIR,10,°C,[min:150;max:300;step:5;default:210]
-r,,PostheaterTemp,PostheaterTemp,,,4050,0b,,,SIR,10,°C,,Min,,SIR,10,°C,[min:150],Max,,SIR,10,°C,[max:300],Step,,SIR,10,°C,[step:5],Default,,SIR,10,°C,[default:210]
-w,,Input1Mode,Input1Mode,,,4080,0c,,,UIR,0=Normally Closed;1=0-10V input;2=Normally Open;3=12V Bypass Open/0V Bypass Closed;4=0V Bypass Open/12V Bypass Closed,,[min:0;max:4;step:1;default:0]
-r,,Input1Mode,Input1Mode,,,4050,0c,,,UIR,0=Normally Closed;1=0-10V input;2=Normally Open;3=12V Bypass Open/0V Bypass Closed;4=0V Bypass Open/12V Bypass Closed,,,,,IGN:6,,,,Default,,UIR,0=Normally Closed;1=0-10V input;2=Normally Open;3=12V Bypass Open/0V Bypass Closed;4=0V Bypass Open/12V Bypass Closed,,[default:0] - min/max/step fields of enum message omitted
-w,,Input1VMin,Input1VMin,,,4080,0d,,,SIR,10,V,[min:0;max:100;step:5;default:0]
-r,,Input1VMin,Input1VMin,,,4050,0d,,,SIR,10,V,,Min,,SIR,10,V,[min:0],Max,,SIR,10,V,[max:100],Step,,SIR,10,V,[step:5],Default,,SIR,10,V,[default:0]
-w,,Input1VMax,Input1VMax,,,4080,0e,,,SIR,10,V,[min:0;max:100;step:5;default:100]
-r,,Input1VMax,Input1VMax,,,4050,0e,,,SIR,10,V,,Min,,SIR,10,V,[min:0],Max,,SIR,10,V,[max:100],Step,,SIR,10,V,[step:5],Default,,SIR,10,V,[default:100]
-w,,CN1Coupling,CN1Coupling,,,4080,0f,,,UIR,0=off;1=on;2=on if bypass open condition satisfied;3=bypass control;4=Bedroom valve,,[min:0;max:4;step:1;default:0]
-r,,CN1Coupling,CN1Coupling,,,4050,0f,,,UIR,0=off;1=on;2=on if bypass open condition satisfied;3=bypass control;4=Bedroom valve,,,,,IGN:6,,,,Default,,UIR,0=off;1=on;2=on if bypass open condition satisfied;3=bypass control;4=Bedroom valve,,[default:0] - min/max/step fields of enum message omitted
-w,,CN1Inlet,CN1Inlet,,,4080,10,,,UIR,0=FanOff;1=Minimal flow 50m³/h;2=FanMode1;3=FanMode2;4=FanMode3;5=ManualSwitch;6=MaximalFlow;7=FanNotActive,,[min:0;max:7;step:1;default:5]
-r,,CN1Inlet,CN1Inlet,,,4050,10,,,UIR,0=FanOff;1=Minimal flow 50m³/h;2=FanMode1;3=FanMode2;4=FanMode3;5=ManualSwitch;6=MaximalFlow;7=FanNotActive,,,,,IGN:6,,,,Default,,UIR,0=FanOff;1=Minimal flow 50m³/h;2=FanMode1;3=FanMode2;4=FanMode3;5=ManualSwitch;6=MaximalFlow;7=FanNotActive,,[default:5] - min/max/step fields of enum message omitted
-w,,CN1Exhaust,CN1Exhaust,,,4080,11,,,UIR,0=FanOff;1=Minimal flow 50m³/h;2=FanMode1;3=FanMode2;4=FanMode3;5=ManualSwitch;6=MaximalFlow;7=FanNotActive,,[min:0;max:7;step:1;default:5]
-r,,CN1Exhaust,CN1Exhaust,,,4050,11,,,UIR,0=FanOff;1=Minimal flow 50m³/h;2=FanMode1;3=FanMode2;4=FanMode3;5=ManualSwitch;6=MaximalFlow;7=FanNotActive,,,,,IGN:6,,,,Default,,UIR,0=FanOff;1=Minimal flow 50m³/h;2=FanMode1;3=FanMode2;4=FanMode3;5=ManualSwitch;6=MaximalFlow;7=FanNotActive,,[default:5] - min/max/step fields of enum message omitted
-w,,Input2Mode,Input2Mode,,,4080,12,,,UIR,0=Normally Closed;1=0-10V input;2=Normally Open;3=12V Bypass Open/0V Bypass Closed;4=0V Bypass Open/12V Bypass Closed,,[min:0;max:4;step:1;default:1]
-r,,Input2Mode,Input2Mode,,,4050,12,,,UIR,0=Normally Closed;1=0-10V input;2=Normally Open;3=12V Bypass Open/0V Bypass Closed;4=0V Bypass Open/12V Bypass Closed,,,,,IGN:6,,,,Default,,UIR,0=Normally Closed;1=0-10V input;2=Normally Open;3=12V Bypass Open/0V Bypass Closed;4=0V Bypass Open/12V Bypass Closed,,[default:1] - min/max/step fields of enum message omitted
-w,,Input2VMin,Input2VMin,,,4080,13,,,SIR,10,V,[min:0;max:100;step:5;default:0]
-r,,Input2VMin,Input2VMin,,,4050,13,,,SIR,10,V,,Min,,SIR,10,V,[min:0],Max,,SIR,10,V,[max:100],Step,,SIR,10,V,[step:5],Default,,SIR,10,V,[default:0]
-w,,Input2VMax,Input2VMax,,,4080,14,,,SIR,10,V,[min:0;max:100;step:5;default:100]
-r,,Input2VMax,Input2VMax,,,4050,14,,,SIR,10,V,,Min,,SIR,10,V,[min:0],Max,,SIR,10,V,[max:100],Step,,SIR,10,V,[step:5],Default,,SIR,10,V,[default:100]
-w,,CN2Coupling,CN2Coupling,,,4080,15,,,UIR,0=off;1=on;2=on if bypass open condition satisfied;3=bypass control;4=Bedroom valve,,[min:0;max:4;step:1;default:0]
-r,,CN2Coupling,CN2Coupling,,,4050,15,,,UIR,0=off;1=on;2=on if bypass open condition satisfied;3=bypass control;4=Bedroom valve,,,,,IGN:6,,,,Default,,UIR,0=off;1=on;2=on if bypass open condition satisfied;3=bypass control;4=Bedroom valve,,[default:0] - min/max/step fields of enum message omitted
-w,,CN2Inlet,CN2Inlet,,,4080,16,,,UIR,0=FanOff;1=Minimal flow 50m³/h;2=FanMode1;3=FanMode2;4=FanMode3;5=ManualSwitch;6=MaximalFlow;7=FanNotActive,,[min:0;max:7;step:1;default:5]
-r,,CN2Inlet,CN2Inlet,,,4050,16,,,UIR,0=FanOff;1=Minimal flow 50m³/h;2=FanMode1;3=FanMode2;4=FanMode3;5=ManualSwitch;6=MaximalFlow;7=FanNotActive,,,,,IGN:6,,,,Default,,UIR,0=FanOff;1=Minimal flow 50m³/h;2=FanMode1;3=FanMode2;4=FanMode3;5=ManualSwitch;6=MaximalFlow;7=FanNotActive,,[default:5] - min/max/step fields of enum message omitted
-w,,CN2Exhaust,CN2Exhaust,,,4080,17,,,UIR,0=FanOff;1=Minimal flow 50m³/h;2=FanMode1;3=FanMode2;4=FanMode3;5=ManualSwitch;6=MaximalFlow;7=FanNotActive,,[min:0;max:7;step:1;default:5]
-r,,CN2Exhaust,CN2Exhaust,,,4050,17,,,UIR,0=FanOff;1=Minimal flow 50m³/h;2=FanMode1;3=FanMode2;4=FanMode3;5=ManualSwitch;6=MaximalFlow;7=FanNotActive,,,,,IGN:6,,,,Default,,UIR,0=FanOff;1=Minimal flow 50m³/h;2=FanMode1;3=FanMode2;4=FanMode3;5=ManualSwitch;6=MaximalFlow;7=FanNotActive,,[default:5] - min/max/step fields of enum message omitted
-w,,EWTMode,EWTMode,,,4080,18,,,UIR,0=off;1=on,,[min:0;max:1;step:1;default:0]
-r,,EWTMode,EWTMode,,,4050,18,,,UIR,0=off;1=on,,,,,IGN:6,,,,Default,,UIR,0=off;1=on,,[default:0] - min/max/step fields of enum message omitted
-w,,EWTTempMin,EWTTempMin,,,4080,19,,,SIR,10,°C,[min:0;max:100;step:5;default:50]
-r,,EWTTempMin,EWTTempMin,,,4050,19,,,SIR,10,°C,,Min,,SIR,10,°C,[min:0],Max,,SIR,10,°C,[max:100],Step,,SIR,10,°C,[step:5],Default,,SIR,10,°C,[default:50]
-w,,EWTTempMax,EWTTempMax,,,4080,1a,,,SIR,10,°C,[min:150;max:400;step:5;default:250]
-r,,EWTTempMax,EWTTempMax,,,4050,1a,,,SIR,10,°C,,Min,,SIR,10,°C,[min:150],Max,,SIR,10,°C,[max:400],Step,,SIR,10,°C,[step:5],Default,,SIR,10,°C,[default:250]
-w,,RHTSensorPresent,RHTSensorPresent,,,4080,32,,,UIR,,,[min:0;max:1;step:1;default:0]
-r,,RHTSensorPresent,RHTSensorPresent,,,4050,32,,,UIR,,,,Min,,UIR,,,[min:0],Max,,UIR,,,[max:1],Step,,UIR,,,[step:1],Default,,UIR,,,[default:0]
-w,,RHTSensorSensitivity,RHTSensorSensitivity,,,4080,33,,,SIR,,,[min:-2;max:2;step:1;default:0]
-r,,RHTSensorSensitivity,RHTSensorSensitivity,,,4050,33,,,SIR,,,,Min,,SIR,,,[min:-2],Max,,SIR,,,[max:2],Step,,SIR,,,[step:1],Default,,SIR,,,[default:0]
+w,,TemperaturePostheater,PostheaterTemp,,,4080,0b,,,SIR,10,°C,[min:150;max:300;step:5;default:210]
+r,,TemperaturePostheater,PostheaterTemp,,,4050,0b,,,SIR,10,°C,,Min,,SIR,10,°C,[min:150],Max,,SIR,10,°C,[max:300],Step,,SIR,10,°C,[step:5],Default,,SIR,10,°C,[default:210]
+w,,SelectionInput1,Input1Mode,,,4080,0c,,,UIR,0=Normally Closed;1=0-10V input;2=Normally Open;3=12V Bypass Open/0V Bypass Closed;4=0V Bypass Open/12V Bypass Closed,,[min:0;max:4;step:1;default:0]
+r,,SelectionInput1,Input1Mode,,,4050,0c,,,UIR,0=Normally Closed;1=0-10V input;2=Normally Open;3=12V Bypass Open/0V Bypass Closed;4=0V Bypass Open/12V Bypass Closed,,,,,IGN:6,,,,Default,,UIR,0=Normally Closed;1=0-10V input;2=Normally Open;3=12V Bypass Open/0V Bypass Closed;4=0V Bypass Open/12V Bypass Closed,,[default:0] - min/max/step fields of enum message omitted
+w,,MinimumVoltageInput1,Input1VMin,,,4080,0d,,,SIR,10,V,[min:0;max:100;step:5;default:0]
+r,,MinimumVoltageInput1,Input1VMin,,,4050,0d,,,SIR,10,V,,Min,,SIR,10,V,[min:0],Max,,SIR,10,V,[max:100],Step,,SIR,10,V,[step:5],Default,,SIR,10,V,[default:0]
+w,,MaximumVoltageInput1,Input1VMax,,,4080,0e,,,SIR,10,V,[min:0;max:100;step:5;default:100]
+r,,MaximumVoltageInput1,Input1VMax,,,4050,0e,,,SIR,10,V,,Min,,SIR,10,V,[min:0],Max,,SIR,10,V,[max:100],Step,,SIR,10,V,[step:5],Default,,SIR,10,V,[default:100]
+w,,ConditionsSwInput1,CN1Coupling,,,4080,0f,,,UIR,0=off;1=on;2=on if bypass open condition satisfied;3=bypass control;4=Bedroom valve,,[min:0;max:4;step:1;default:0]
+r,,ConditionsSwInput1,CN1Coupling,,,4050,0f,,,UIR,0=off;1=on;2=on if bypass open condition satisfied;3=bypass control;4=Bedroom valve,,,,,IGN:6,,,,Default,,UIR,0=off;1=on;2=on if bypass open condition satisfied;3=bypass control;4=Bedroom valve,,[default:0] - min/max/step fields of enum message omitted
+w,,SupplyFanModeSwInput1,CN1Inlet,,,4080,10,,,UIR,0=FanOff;1=Minimal flow 50m³/h;2=FanMode1;3=FanMode2;4=FanMode3;5=ManualSwitch;6=MaximalFlow;7=FanNotActive,,[min:0;max:7;step:1;default:5]
+r,,SupplyFanModeSwInput1,CN1Inlet,,,4050,10,,,UIR,0=FanOff;1=Minimal flow 50m³/h;2=FanMode1;3=FanMode2;4=FanMode3;5=ManualSwitch;6=MaximalFlow;7=FanNotActive,,,,,IGN:6,,,,Default,,UIR,0=FanOff;1=Minimal flow 50m³/h;2=FanMode1;3=FanMode2;4=FanMode3;5=ManualSwitch;6=MaximalFlow;7=FanNotActive,,[default:5] - min/max/step fields of enum message omitted
+w,,ExtractFanModeSwInput1,CN1Exhaust,,,4080,11,,,UIR,0=FanOff;1=Minimal flow 50m³/h;2=FanMode1;3=FanMode2;4=FanMode3;5=ManualSwitch;6=MaximalFlow;7=FanNotActive,,[min:0;max:7;step:1;default:5]
+r,,ExtractFanModeSwInput1,CN1Exhaust,,,4050,11,,,UIR,0=FanOff;1=Minimal flow 50m³/h;2=FanMode1;3=FanMode2;4=FanMode3;5=ManualSwitch;6=MaximalFlow;7=FanNotActive,,,,,IGN:6,,,,Default,,UIR,0=FanOff;1=Minimal flow 50m³/h;2=FanMode1;3=FanMode2;4=FanMode3;5=ManualSwitch;6=MaximalFlow;7=FanNotActive,,[default:5] - min/max/step fields of enum message omitted
+w,,SelectionInput2,Input2Mode,,,4080,12,,,UIR,0=Normally Closed;1=0-10V input;2=Normally Open;3=12V Bypass Open/0V Bypass Closed;4=0V Bypass Open/12V Bypass Closed,,[min:0;max:4;step:1;default:1]
+r,,SelectionInput2,Input2Mode,,,4050,12,,,UIR,0=Normally Closed;1=0-10V input;2=Normally Open;3=12V Bypass Open/0V Bypass Closed;4=0V Bypass Open/12V Bypass Closed,,,,,IGN:6,,,,Default,,UIR,0=Normally Closed;1=0-10V input;2=Normally Open;3=12V Bypass Open/0V Bypass Closed;4=0V Bypass Open/12V Bypass Closed,,[default:1] - min/max/step fields of enum message omitted
+w,,MinimumVoltageInput2,Input2VMin,,,4080,13,,,SIR,10,V,[min:0;max:100;step:5;default:0]
+r,,MinimumVoltageInput2,Input2VMin,,,4050,13,,,SIR,10,V,,Min,,SIR,10,V,[min:0],Max,,SIR,10,V,[max:100],Step,,SIR,10,V,[step:5],Default,,SIR,10,V,[default:0]
+w,,MaximumVoltageInput2,Input2VMax,,,4080,14,,,SIR,10,V,[min:0;max:100;step:5;default:100]
+r,,MaximumVoltageInput2,Input2VMax,,,4050,14,,,SIR,10,V,,Min,,SIR,10,V,[min:0],Max,,SIR,10,V,[max:100],Step,,SIR,10,V,[step:5],Default,,SIR,10,V,[default:100]
+w,,ConditionsSwInput2,CN2Coupling,,,4080,15,,,UIR,0=off;1=on;2=on if bypass open condition satisfied;3=bypass control;4=Bedroom valve,,[min:0;max:4;step:1;default:0]
+r,,ConditionsSwInput2,CN2Coupling,,,4050,15,,,UIR,0=off;1=on;2=on if bypass open condition satisfied;3=bypass control;4=Bedroom valve,,,,,IGN:6,,,,Default,,UIR,0=off;1=on;2=on if bypass open condition satisfied;3=bypass control;4=Bedroom valve,,[default:0] - min/max/step fields of enum message omitted
+w,,SupplyFanModeSwInput2,CN2Inlet,,,4080,16,,,UIR,0=FanOff;1=Minimal flow 50m³/h;2=FanMode1;3=FanMode2;4=FanMode3;5=ManualSwitch;6=MaximalFlow;7=FanNotActive,,[min:0;max:7;step:1;default:5]
+r,,SupplyFanModeSwInput2,CN2Inlet,,,4050,16,,,UIR,0=FanOff;1=Minimal flow 50m³/h;2=FanMode1;3=FanMode2;4=FanMode3;5=ManualSwitch;6=MaximalFlow;7=FanNotActive,,,,,IGN:6,,,,Default,,UIR,0=FanOff;1=Minimal flow 50m³/h;2=FanMode1;3=FanMode2;4=FanMode3;5=ManualSwitch;6=MaximalFlow;7=FanNotActive,,[default:5] - min/max/step fields of enum message omitted
+w,,ExtractFanModeSwInput2,CN2Exhaust,,,4080,17,,,UIR,0=FanOff;1=Minimal flow 50m³/h;2=FanMode1;3=FanMode2;4=FanMode3;5=ManualSwitch;6=MaximalFlow;7=FanNotActive,,[min:0;max:7;step:1;default:5]
+r,,ExtractFanModeSwInput2,CN2Exhaust,,,4050,17,,,UIR,0=FanOff;1=Minimal flow 50m³/h;2=FanMode1;3=FanMode2;4=FanMode3;5=ManualSwitch;6=MaximalFlow;7=FanNotActive,,,,,IGN:6,,,,Default,,UIR,0=FanOff;1=Minimal flow 50m³/h;2=FanMode1;3=FanMode2;4=FanMode3;5=ManualSwitch;6=MaximalFlow;7=FanNotActive,,[default:5] - min/max/step fields of enum message omitted
+w,,GeoHeatExchanger,EWTMode,,,4080,18,,,UIR,0=off;1=on,,[min:0;max:1;step:1;default:0]
+r,,GeoHeatExchanger,EWTMode,,,4050,18,,,UIR,0=off;1=on,,,,,IGN:6,,,,Default,,UIR,0=off;1=on,,[default:0] - min/max/step fields of enum message omitted
+w,,MinTempGeoHeatExchanger,EWTTempMin,,,4080,19,,,SIR,10,°C,[min:0;max:100;step:5;default:50]
+r,,MinTempGeoHeatExchanger,EWTTempMin,,,4050,19,,,SIR,10,°C,,Min,,SIR,10,°C,[min:0],Max,,SIR,10,°C,[max:100],Step,,SIR,10,°C,[step:5],Default,,SIR,10,°C,[default:50]
+w,,MaxTempGeoHeatExchanger,EWTTempMax,,,4080,1a,,,SIR,10,°C,[min:150;max:400;step:5;default:250]
+r,,MaxTempGeoHeatExchanger,EWTTempMax,,,4050,1a,,,SIR,10,°C,,Min,,SIR,10,°C,[min:150],Max,,SIR,10,°C,[max:400],Step,,SIR,10,°C,[step:5],Default,,SIR,10,°C,[default:250]
+w,,RHSensorPresent,RHTSensorPresent,,,4080,32,,,UIR,,,[min:0;max:1;step:1;default:0]
+r,,RHSensorPresent,RHTSensorPresent,,,4050,32,,,UIR,,,,Min,,UIR,,,[min:0],Max,,UIR,,,[max:1],Step,,UIR,,,[step:1],Default,,UIR,,,[default:0]
+w,,RHSensorSensitivity,RHTSensorSensitivity,,,4080,33,,,SIR,,,[min:-2;max:2;step:1;default:0]
+r,,RHSensorSensitivity,RHTSensorSensitivity,,,4050,33,,,SIR,,,,Min,,SIR,,,[min:-2],Max,,SIR,,,[max:2],Step,,SIR,,,[step:1],Default,,SIR,,,[default:0]
 w,,BacklightLevel,BacklightLevel,,,4080,1d,,,UIR,,%,[min:0;max:100;step:5;default:10]
 r,,BacklightLevel,BacklightLevel,,,4050,1d,,,UIR,,%,,Min,,UIR,,%,[min:0],Max,,UIR,,%,[max:100],Step,,UIR,,%,[step:5],Default,,UIR,,%,[default:10]
 w,,CO2Sensor1LowerLimit,CO2Sensor1LowerLimit,,,4080,34,,,UIR,,ppm,[min:400;max:2000;step:25;default:400]
@@ -144,8 +146,8 @@ w,,CO2SensorsActivated,CO2SensorsActivated,,,4080,3c,,,UIR,0=no;1=yes,,[min:0;ma
 r,,CO2SensorsActivated,CO2SensorsActivated,,,4050,3c,,,UIR,0=no;1=yes,,,,,IGN:6,,,,Default,,UIR,0=no;1=yes,,[default:0] - min/max/step fields of enum message omitted
 w,,FlowCorrection,FlowCorrection,,,4080,3f,,,UIR,,%,[min:90;max:110;step:1;default:100]
 r,,FlowCorrection,FlowCorrection,,,4050,3f,,,UIR,,%,,Min,,UIR,,%,[min:90],Max,,UIR,,%,[max:110],Step,,UIR,,%,[step:1],Default,,UIR,,%,[default:100]
-w,,SwitchDefaultPos,SwitchDefaultPos,,,4080,40,,,UIR,0=off;1=on,,[min:0;max:1;step:1;default:1]
-r,,SwitchDefaultPos,SwitchDefaultPos,,,4050,40,,,UIR,0=off;1=on,,,,,IGN:6,,,,Default,,UIR,0=off;1=on,,[default:1] - min/max/step fields of enum message omitted
+w,,DefaultPositionSwitch,SwitchDefaultPos,,,4080,40,,,UIR,0=off;1=on,,[min:0;max:1;step:1;default:1]
+r,,DefaultPositionSwitch,SwitchDefaultPos,,,4050,40,,,UIR,0=off;1=on,,,,,IGN:6,,,,Default,,UIR,0=off;1=on,,[default:1] - min/max/step fields of enum message omitted
 w,,FilterDaysBeforeWarning,FilterDaysBeforeWarning,,,4080,45,,,UIR,,,[min:1;max:365;step:1;default:90]
 r,,FilterDaysBeforeWarning,FilterDaysBeforeWarning,,,4050,45,,,UIR,,,,Min,,UIR,,,[min:1],Max,,UIR,,,[max:365],Step,,UIR,,,[step:1],Default,,UIR,,,[default:90]
 w,,ModbusInterface,ModbusInterface,,,4080,41,,,UIR,,,[min:0;max:3;step:2;default:1]

--- a/3c.renovent-excellent-300.csv
+++ b/3c.renovent-excellent-300.csv
@@ -1,117 +1,158 @@
-# type (r[1-9];w;u),circuit,name,[comment],[QQ],ZZ,PBSB,[ID],field1,part (m/s),datatypes/templates,divider/values,unit,comment,field2,part (m/s),datatypes/templates ,divider/values,unit,comment,field3,part (m/s),datatypes/templates,divider/values,unit,comment,field4,part (m/s),datatypes/templates,divider/values,unit,comment,field5,part (m/s),datatypes/templates,divider/values,unit,comment
-### BRINK RENOVENT EXCELLENT 300 & 400 (plus)
-##
-## This ebus config may work for Ubbink, VisionAIR, WOLF CWL series and some other systems that are identical
-## You may need to modify the 7c address in the next 2 lines for your brand/model. Or just uncomment the necessary lines.
+# type (r[1-9];w;u),circuit,name,[comment],[QQ],ZZ,PBSB,[ID],field1,part (m/s),datatypes/templates,divider/values,unit,comment,field2,part (m/s),datatypes/templates,divider/values,unit,comment,field3,part (m/s),datatypes/templates,divider/values,unit,comment,field4,part (m/s),datatypes/templates,divider/values,unit,comment,field5,part (m/s),datatypes/templates,divider/values,unit,comment
+## Diese Ebus-Konfiguration könnte für Ubbink, VisionAIR, WOLF CWL Serien, Viessmann und einige andere Systeme funktionieren, die nur umgebrandete Brink-Geräte sind
+## Quellen:
+## - Ursprüngliche Idee und einige Trennzeichen: https://github.com/dstrigl/ebusd-config-brink-renovent-excellent-300
+## - Brink Service Tool (decompiliert via Jetbrains DotPeak): https://www.brinkclimatesystems.nl/tools/software-brink-service-tool-en
+## - Renovent 150 Datenblatt: https://manuals.plus/brink/renovent-sky-150-plus-mechanical-ventilation-with-heat-recovery-manual
+## - Modbus Modul Datenblatt: https://www.brinkclimatesystems.nl/documenten/modbus-uwa2-b-uwa2-e-installation-regulations-614882.pdf
+## Nachrichtennamen basieren auf den offiziellen Übersetzungen des Brink Service Tools mit entfernten Leerzeichen und Sonderzeichen.
+## Nachrichtenkommentar ist der Name des Parameters, wie er intern im Code verwendet wird (um zu helfen, wenn die Übersetzung selbst verwirrend ist)
 
-## Renovent Excellent 400 (plus) series
-## *r,kwl,,,,7c,4050,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-## *w,kwl,,,,7c,4050,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+*r,Excellent300,,,,3c,
+*w,Excellent300,,,,3c,
 
-## Renovent Excellent 300 series
-*r,kwl,,,,3c,4050,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-*w,kwl,,,,3c,4050,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+## ALLGEMEINE HRU BEFEHLE ## (WTWCommands.cs - Einige davon sind möglicherweise nicht für dieses Gerät anwendbar, mit Vorsicht verwenden)
+w,,RücksetzenAufWerkseinstellung,FactoryReset,,,40ff,466163746f72795265736574
+w,,Fehlerliste,ResetNotifications,,,4091,,,,UIR,0x0001=Errors;0x0100=Filter;0x0101=ErrorsAndFilter;0x0000=NoResetRequested,,NoResetRequested is a dummy message doing nothing. It might be useful for integration in MQTT and HA automation.
+r,,GespeicherteFehler,RequestErrorList,,,4090,,,,HEX:18,,,
+w,,Ventilatorbetrieb,FanMode,,,40a1,,,,ULR,0x0=Holiday;0x00010001=Reduced;0x00020002=Normal;0x00030003=High,,
+r,,MaximalerDurchsatzFilter,FilterNotificationFlow,,,4050,1c,,,UIR,-1000,m³,,Min,,UIR,-1000,m³,,Max,,UIR,-1000,m³,,Step,,UIR,-1000,m³,,Default,,UIR,-1000,m³,
+r,,FilterverwendungTage,TotalFilterDays,,,4050,22,,,UIR,,Days,,Min,,UIR,,Days,,Max,,UIR,,Days,,Step,,UIR,,Days,,Default,,UIR,,Days,
+r,,Filterverwendung,TotalFilterFlow,,,4050,23,,,UIR,-1000,m³,,Min,,UIR,-1000,m³,,Max,,UIR,-1000,m³,,Step,,UIR,-1000,m³,,Default,,UIR,-1000,m³,
+r,,Betriebsdauer,TotalOperatingHours,,,4050,24,,,UIR,-5,Hours,,Min,,UIR,-5,Hours,,Max,,UIR,-5,Hours,,Step,,UIR,-5,Hours,,Default,,UIR,-5,Hours,
+r,,Gesamtdurchsatz1000m3,TotalFlow,,,4050,25,,,UIR,-1000,m³,,Min,,UIR,-1000,m³,,Max,,UIR,-1000,m³,,Step,,UIR,-1000,m³,,Default,,UIR,-1000,m³,
 
-#### AKTUELLE KONFIGDATEN ####
-r1,,LuftmengeStufe0,,,,4050,21,aktuell,,UIR,,m³/h,,minimum,,UIR,,m³/h,,maximum,,UIR,,m³/h,,Schrittgroesse,,UIR,,m³/h,,Werkseinstellung,,UIR,,m³/h
-r1,,LuftmengeStufe1,,,,4050,01,aktuell,,UIR,,m³/h,,minimum,,UIR,,m³/h,,maximum,,UIR,,m³/h,,Schrittgroesse,,UIR,,m³/h,,Werkseinstellung,,UIR,,m³/h
-r1,,LuftmengeStufe2,,,,4050,02,aktuell,,UIR,,m³/h,,minimum,,UIR,,m³/h,,maximum,,UIR,,m³/h,,Schrittgroesse,,UIR,,m³/h,,Werkseinstellung,,UIR,,m³/h
-r1,,LuftmengeStufe3,,,,4050,03,aktuell,,UIR,,m³/h,,minimum,,UIR,,m³/h,,maximum,,UIR,,m³/h,,Schrittgroesse,,UIR,,m³/h,,Werkseinstellung,,UIR,,m³/h
-r1,,BypassTemperatur,,,,4050,04,aktuell,,SIR,10,°C,,minimum,,SIR,10,°C,,maximum,,SIR,10,°C,,Schrittgroesse,,SIR,10,°C,,Werkseinstellung,,SIR,10,°C
-r1,,BypassHysterese,,,,4050,30,aktuell,,SIR,10,°C,,minimum,,SIR,10,°C,,maximum,,SIR,10,°C,,Schrittgroesse,,SIR,10,°C,,Werkseinstellung,,SIR,10,°C
-r1,,Bypassbetrieb,,,,4050,1b,aktuell,,UIR,0=auto;1=geschlossen;2=geoeffnet,,,minimum,,UIR,,,,maximum,,UIR,,,,Schrittgroesse,,UIR,,,,Werkseinstellung,,UIR
-r1,,ZentralheizungWRG,,,,4050,07,aktuell,s,UIR,0=aus;1=ein,,,minimum,,UIR,,,,maximum,,UIR,,,,Schrittgroesse,,UIR,,,,Werkseinstellung,,UIR
-r1,,DruckungleichgewichtZulaessig,,,,4050,08,aktuell,s,UIR,0=nicht zulaessig;1=zulaessig,,,minimum,,UIR,,,,maximum,,UIR,,,,Schrittgroesse,,UIR,,,,Werkseinstellung,,UIR
-r1,,FestesDruckungleichgewicht,,,,4050,09,aktuell,,SIR,,m³/h,,minimum,,SIR,,m³/h,,maximum,,SIR,,m³/h,,Schrittgroesse,,SIR,,m³/h,,Werkseinstellung,,SIR,,m³/h
-r1,,RHSensorVorhanden,,,,4050,32,aktuell,,UIR,,,,minimum,,UIR,,,,maximum,,UIR,,,,Schrittgroesse,,UIR,,,,Werkseinstellung,,UIR,,
-r1,,RHSensorEmpfindlichkeit,,,,4050,33,aktuell,,SIR,,,,minimum,,SIR,,,,maximum,,SIR,,,,Schrittgroesse,,SIR,,,,Werkseinstellung,,SIR
-r1,,BeleuchtungDisplay,,,,4050,1d,aktuell,,UIR,,%,,minimum,,UIR,,%,,maximum,,UIR,,%,,Schrittgroesse,,UIR,,%,,Werkseinstellung,,UIR,,%
-r1,,VorheizRegister_inst,,,,4050,31,aktuell,,UIR,1=ja;0=nein
+## Aktueller Zustand und Sensoren ##
+r,,Ventilatorbetrieb,FanMode,,,4022,01,,,UIR,0=Holiday;1=Reduced;2=Normal;3=High;4=Auto,,
+r,,Zuluftmenge,SettingInletFlow,,,4022,09,,,UIR,,m³/h,
+r,,Abluftmenge,SettingExhaustFlow,,,4022,0a,,,UIR,,m³/h,
+r,,TatsächlicheZuluftmenge,InletFlow,,,4022,0b,,,UIR,,m³/h,
+r,,TatsächlicheAbluftmenge,ExhaustFlow,,,4022,0c,,,UIR,,m³/h,
+r,,TatsächlicheDrehzahlZuluft,InletFanSpeed,,,4022,02,,,UIR,,rpm,
+r,,TatsächlicheDrehzahlAbluft,ExhaustFanSpeed,,,4022,03,,,UIR,,rpm,
+r,,PositionPerilexschalter,PerilexPosition,,,4022,05,,,UIR,0=Position_0;1=Position_1;2=Position_2;3=Position_3;,,
+r,,PositionStufenschalter,SwitchPosition,,,4022,06,,,UIR,0=Position_0;1=Position_1;2=Position_2;3=Position_3;,,
+r,,PositionSchalteingang1,Contact1Position,,,4022,1b,,,UIR,0=Off;1=On,,
+r,,PositionSchalteingang2,Contact2Position,,,4022,1c,,,UIR,0=Off;1=On,,
+r,,WertDIPSchalter,DipswitchValue,,,4022,04,,,UIR,31=Excellent180Basic;30=Excellent180Plus;7=Excellent300Basic;6=Excellent300Plus;5=Excellent400Basic;4=Excellent400Plus;27=Excellent450Basic;26=Excellent450Plus;3=RenoventElan300Basic;2=RenoventElan300Plus;19=Sky150Basic;18=Sky150Plus;9=Sky200Basic;8=Sky200Plus;21=Sky300Basic;20=Sky300Plus,,
+r,,SoftwareVersion,SoftwareVersion,,,4022,00,,,STR:13,,,
+r,,StatusBypass,BypassStatus,,,4022,0e,,,UIR,0=Initializing;1=Opening;2=Closing;3=Open;4=Closed;5=Error;6=Calibrating;255=Error,,
+r,,StromBypass,BypassCurrent,,,4022,0d,,,UIR,,,
+r,,StatusVorheizregister,PreheaterStatus,,,4022,0f,,,UIR,0=Initializing;1=Off;2=On,,
+r,,LeistungVorheizregister,PreheaterPower,,,4022,10,,,UIR,,%,
+r,,StatusNachheizregister,PostheaterStatus,,,4022,1d,,,UIR,0=Initializing;1=Off;2=On,,
+r,,LeistungNachheizregister,PostheaterPower,,,4022,1e,,,UIR,,%,
+r,,StatusErdreichwärmetauscher,EWTStatus,,,4022,1f,,,UIR,0=OpenLow;1=Closed;2=OpenHigh,,
+r,,StatusFrostschutz,FrostStatus,,,4022,16,,,UIR,0=Initializing;1=NoFrost;17=NoFrost;2=DefrostWait;3=Preheater;18=Preheater;255=Error;5=VeluHeater;6=VeluFanCtrl;7=TableFanCtrl;19=TableFanCtrl;8=Sky150Heater;9=FanCtrlFanOff;10=FanCtrlFanRestart;11=FanCtrlCurve1;12=FanCtrlCurve2;13=FanCtrlCurve3;14=FanCtrlCurve4;15=HeaterCoolDown;16=Blocked,,
+r,,StatusVentilator,FanStatus,,,4022,11,,,UIR,0=Initializing;1=ConstantFlow;2=ConstantPWM;3=Off;4=Error;5=MassBalance;6=Standby;7=ConstantRPM,,
+r,,Ablufttemperatur,InsideTemperature,,,4022,07,,,SIR,10,°C,
+r,,Außenlufttemperatur,OutsideTemperature,,,4022,08,,,SIR,10,°C,
+r,,ZusätzlicherTemperaturfühler,OptionTemperature,,,4022,1a,,,SIR,10,°C,
+r,,Filtermeldung,FilterStatus,,,4022,18,,,UIR,0=Clean;1=Dirty,,
+r,,RelativeFeuchteRHSensor,RelativeHumidity,,,4022,20,,,SIR,10,%,
+r,,FeuchtesensorStatus,HumidityBoostState,,,4022,21,,,UIR,0=Error;1=NotInitialized;2=SensorNotActive;3=PowerUpDelay;4=NormalRH;5=BoostRising;6=BoostStable;7=BoostDecending;8=BoostRHLowLevelStable,Pa,
+r,,IstwertZuluftdruck,PressureInlet,,,4022,14,,,UIR,10,Pa,
+r,,IstwertAbluftdruck,PressureExhaust,,,4022,15,,,UIR,10,Pa,
+r,,EBusSynchFehler,EBusSyncGenErrorCount,,,4022,64,,,UIR,,,
+r,,StatusCO2Sensor1,CO2Sensor1Status,,,4022,28,,,UIR,0=Error;1=NotInitialized;2=Idle;3=WarmingUp;4=Running;5=Calibrating;6=SelfTest,,
+r,,NiveauCO2Sensor1,CO2Sensor1Value,,,4022,29,,,UIR,,ppm,
+r,,StatusCO2Sensor2,CO2Sensor2Status,,,4022,2a,,,UIR,0=Error;1=NotInitialized;2=Idle;3=WarmingUp;4=Running;5=Calibrating;6=SelfTest,,
+r,,NiveauCO2Sensor2,CO2Sensor2Value,,,4022,2b,,,UIR,,ppm,
+r,,StatusCO2Sensor3,CO2Sensor3Status,,,4022,2c,,,UIR,0=Error;1=NotInitialized;2=Idle;3=WarmingUp;4=Running;5=Calibrating;6=SelfTest,,
+r,,NiveauCO2Sensor3,CO2Sensor3Value,,,4022,2d,,,UIR,,ppm,
+r,,StatusCO2Sensor4,CO2Sensor4Status,,,4022,2e,,,UIR,0=Error;1=NotInitialized;2=Idle;3=WarmingUp;4=Running;5=Calibrating;6=SelfTest,,
+r,,NiveauCO2Sensor4,CO2Sensor4Value,,,4022,2f,,,UIR,,ppm,
 
-#### FILTER UND LAUFZEITEN ####
-r1,,TageMitFilter,,,,4050,22,,,UIR,,bei 90 Tagen kommt Filterwarnung 
-r1,,LuftmengeMitFilter,,,,4050,23,,,UIR,,tm³ 
-r1,,LuftmengeFilterSchwellwert,,,,4050,1c,,,UIR,,tm³ 
-r1,,BetriebsstundenTotal,,,,4050,24,,,UIR,-5,h,,,,UIR,,,,,,UIR,,,,,,UIR,,,,,,UIR
-r1,,LuftmengeTotal,,,,4050,25,,,UIR,-1000,m³,,,,UIR,,,,,,UIR,,,,,,UIR,,,,,,UIR
-
-#### KONFIGURATION AENDERN ####
-w,,LuftmengeStufe0,408001,,,4080,21,,,UIR,,m³/h
-w,,LuftmengeStufe1,408001,,,4080,01,,,UIR,,m³/h
-w,,LuftmengeStufe2,408001,,,4080,02,,,UIR,,m³/h
-w,,LuftmengeStufe3,408001,,,4080,03,,,UIR,,m³/h
-w,,BypassTemperatur,408001,,,4080,04,,,UIR,10,°C
-w,,EWTT-,408001,,,4080,19,,,UIR,10,°C
-w,,EWTT+,408001,,,4080,1A,,,UIR,10,°C
-w,,BypassHysterese,408003,,,4080,30,,,UIR,10,°C
-w,,Bypassbetrieb,408003,,,4080,1b,,,UIR,0=auto;1=geschlossen;2=geoeffnet
-w,,VorheizRegister_an,408003,,,4080,31,,,UIR,0=nein;1=ja
-w,,ZentralheizungWRG,408007,,,4080,07,,,UIR,0=aus;1=ein
-w,,DruckungleichgewichtZulaessig,408008,,,4080,08,,,UIR,0=nicht zulaessig;1=zulaessig
-w,,FestesDruckungleichgewicht,408009,,,4080,09,,,SIR,,m³/h
-w,,Ventilatorbetrieb,,,,40a1,,,,ULR,0x0=Feuchteschutz;0x00010001=Reduziert;0x00020002=Normal;0x00030003=Intensiv,,,,,IGN:1
-
-#### SENSORDATEN ####
-r1,,Feuchte,40220120,,,4022,20,,,UIR,10,% ,RelativeHumidity
-r1,,FeuchtigkeitsSteigerung,40220121,,,4022,21,,,UIR,0=Error;1=Not Initialized;2=Sensor Not Active;3=PowerUp Delay;4=Normal RH;5=Boost Rising;6=Boost Stable;7=Boost Decending,,HumidityBoostState
-r1,,SoftwareVersion,40220100,,,4022,00,,,STR:*,,,SoftwareVersion
-r1,,Ventilatorbetrieb,40220101,,,4022,01,,,UIR,0=Feuchteschutz;1=Reduziert;2=Normal;3=Intensiv,,FanMode
-r1,,TatsaechlicheDrehzahlZuluft,40220102,,,4022,02,,,UIR,,rpm,InletFanSpeed
-r1,,TatsaechlicheDrehzahlAbluft,40220103,,,4022,03,,,UIR,,rpm,ExhaustFanSpeed
-r1,,Ablufttemperatur,40220107,,,4022,07,,,SIR,10,°C,InsideTemperature
-r1,,Aussenlufttemperatur,40220108,,,4022,08,,,SIR,10,°C,OutsideTemperature
-r1,,TatsaechlicheZuluftmenge,4022010B,,,4022,0b,,,UIR,,m³/h,InletFlow
-r1,,TatsaechlicheAbluftmenge,4022010C,,,4022,0c,,,UIR,,m³/h,ExhaustFlow
-r1,,IstwertZuluftdruck,40220114,,,4022,14,,,UIR,10,Pa,PressureInlet
-r1,,IstwertAbluftdruck,40220115,,,4022,15,,,UIR,10,Pa,PressureExhaust
-r1,,FilterStatus,40220118,,,4022,18,,,UIR,0=Clean;1=Dirty,,FilterStatus
-r1,,CO2Sensor1Status,40220128,,,4022,28,,,UIR,,,CO2Sensor1Status
-r1,,CO2Sensor1Value,40220129,,,4022,29,,,UIR,,,CO2Sensor1Value
-r1,,CO2Sensor2Status,4022012A,,,4022,2a,,,UIR,,,CO2Sensor2Status
-r1,,CO2Sensor2Value,4022012B,,,4022,2b,,,UIR,,,CO2Sensor2Value
-r1,,CO2Sensor3Status,4022012C,,,4022,2c,,,UIR,,,CO2Sensor3Status
-r1,,CO2Sensor3Value,4022012D,,,4022,2d,,,UIR,,,CO2Sensor3Value
-r1,,CO2Sensor4Status,4022012E,,,4022,2e,,,UIR,,,CO2Sensor4Status
-r1,,CO2Sensor4Value,4022012F,,,4022,2f,,,UIR,,,CO2Sensor4Value
-
-#### SONSTIGES ####
-r1,,Errors,409000,,,4090,00,,s,UCH,,,,ign,,IGN:2,,,,code,,UCH,,,,code,,UCH,,,,code,,UCH,,,,code,,UCH,,,,code,,UCH,,,,code,,UCH,,,,code,,UCH,,,,code,,UCH,,,,code,,UCH,,,,code,,UCH
-#w,,reseterrors,409103FFFFFF,,,4091,7c0001,,m,HEX:3,,,,result,s,UIR,0=ResetNotRequested;1=ResetSuccessful;2=ResetRelayed;3=NoErrorsFound;4=ResetFailed;5=BlockingErrors;6=UnknownResult
-#w,,resetfilter,409103FFFFFF,,,4091,7c0100,,,,,,,result,s,UIR,0=ResetNotRequested;1=ResetSuccessful;2=ResetRelayed;3=FilterWarningWasNotSet;4=ResetFailed;5=UnknownResult
-r1,,PosStufenschalter,,,,4022,06,,,UIR,,,switchposition
-r1,,WertDIPSchalter,40220104,,,4022,04,,,UIR,,,DipswitchValue
-r1,,LuefterStatus,40220111,,,4022,11,,,UIR,0=Initialize;1=Const. Flow;2=Const. RPM;3=Off;4=Error,,FanStatus
-r1,,SollZuluftmenge,40220109,,,4022,09,,,UIR,,m³/h,SettingInletFlow
-r1,,SollAbluftmenge,4022010A,,,4022,0a,,,UIR,,m³/h,SettingExhaustFlow
-r1,,Bypassstrom,4022010D,,,4022,0D,,,UIR,,,BypassCurrent
-r1,,StatusBypass,4022010E,,,4022,0E,,,UIR,0=Initialize;1=Opening;2=Closing;3=Open;4=Closed;5=Error;255=Unknown,,BypassStatus
-r1,,StatusVorheizregister,4022010F,,,4022,0F,,,UIR,0=Initialize;1=Disabled;2=Enabled;3=Testmode;255=Unknown,,PreheaterStatus
-r1,,LeistungVorheizregister,40220110,,,4022,10,,,UIR,,,PreheaterPower
-r1,,StatusNachheizregister,4022011D,,,4022,1d,,,UIR,0=Initialize;1=Disabled;2=Enabled,,PostheaterStatus
-r1,,LeistungNachheizregister,4022011E,,,4022,1e,,,UIR,,,PostheaterPower
-r1,,FrostStatus,40220116,,,4022,16,,,UIR,0=Initialize;1=No Frost;2=Defrost Wait;3=Heater;4=Error;5=Velu Heater;6=Velu Unbalance;7=Unbalanace,,FrostStatus
-r1,,eBusSyncFehler,40220164,,,4022,64,,,UIR,,,EbusSyncGenErrorCount
-r1,,PerilexPosition,40220105,,,4022,05,,,UIR,,,PerilexPosition
-r1,,Contact1Position,4022011B,,,4022,1b,,,UIR,,,Contact1Position
-r1,,Contact2Position,4022011C,,,4022,1c,,,UIR,,,Contact2Position
-r1,,EWTStatus,4022011F,,,4022,1f,,,UIR,2=Precool;1=Disabled;0=Preheat,,EWTStatus
-r1,,EWTT-,40500119,,,4050,19,aktuell,,SIR,10,°C,,minimum,,SIR,10,°C,,maximum,,SIR,10,°C,,Schrittgroesse,,SIR,10,°C,,Werkseinstellung,,SIR,10,°C
-r1,,EWTT+,4050011A,,,4050,1A,aktuell,,SIR,10,°C,,minimum,,SIR,10,°C,,maximum,,SIR,10,°C,,Schrittgroesse,,SIR,10,°C,,Werkseinstellung,,SIR,10,°C
-r1,,OptionTemperature,4022011A,,,4022,1a,,,UIR,,,OptionTemperature
-
-#### UNDEFINIERT ####
-#r,,undef_01,undef,,,,0a,,,HEX:10
-#r,,undef_02,undef,,,,0b,,,HEX:10
-#r,,undef_03,undef,,,,0c,,,HEX:10
-#r,,undef_04,undef,,,,0d,,,HEX:10
-#r,,undef_05,undef,,,,0e,,,HEX:10
-#r,,undef_06,undef,,,,0f,,,HEX:10
-#r,,undef_07,undef,,,,10,,,HEX:10
-#r,,undef_08,undef,,,,11,,,HEX:10
-#r,,undef_09,undef,,,,12,,,HEX:10
-#r,,undef_10,undef,,,,13,,,HEX:10
-#r,,undef_11,undef,,,,14,,,HEX:10
-#r,,undef_12,undef,,,,15,,,HEX:10
-#r,,undef_13,undef,,,,16,,,HEX:10
-#r,,undef_14,undef,,,,17,,,HEX:10
-#r,,undef_15,undef,,,,18,,,HEX:10
+## Konfigurationsparameter ## (Werte in Klammern neben dem Feld sind Definitionen dieser Feldwerte aus dem Brink Service Tool.)
+w,,LuftmengeStufe0,FlowMode0,,,4080,21,,,SIR,,m³/h,[min:0;max:50;step:50;default:50]
+r,,LuftmengeStufe0,FlowMode0,,,4050,21,,,SIR,,m³/h,,Min,,SIR,,m³/h,[min:0],Max,,SIR,,m³/h,[max:50],Step,,SIR,,m³/h,[step:50],Default,,SIR,,m³/h,[default:50]
+w,,LuftmengeStufe1,FlowMode1,,,4080,01,,,SIR,,m³/h,[min:50;max:300;step:5;default:100]
+r,,LuftmengeStufe1,FlowMode1,,,4050,01,,,SIR,,m³/h,,Min,,SIR,,m³/h,[min:50],Max,,SIR,,m³/h,[max:300],Step,,SIR,,m³/h,[step:5],Default,,SIR,,m³/h,[default:100]
+w,,LuftmengeStufe2,FlowMode2,,,4080,02,,,SIR,,m³/h,[min:50;max:300;step:5;default:150]
+r,,LuftmengeStufe2,FlowMode2,,,4050,02,,,SIR,,m³/h,,Min,,SIR,,m³/h,[min:50],Max,,SIR,,m³/h,[max:300],Step,,SIR,,m³/h,[step:5],Default,,SIR,,m³/h,[default:150]
+w,,LuftmengeStufe3,FlowMode3,,,4080,03,,,SIR,,m³/h,[min:50;max:300;step:5;default:225]
+r,,LuftmengeStufe3,FlowMode3,,,4050,03,,,SIR,,m³/h,,Min,,SIR,,m³/h,[min:50],Max,,SIR,,m³/h,[max:300],Step,,SIR,,m³/h,[step:5],Default,,SIR,,m³/h,[default:225]
+w,,BypassTemperatur,BypassTemp,,,4080,04,,,SIR,10,°C,[min:150;max:350;step:5;default:240]
+r,,BypassTemperatur,BypassTemp,,,4050,04,,,SIR,10,°C,,Min,,SIR,10,°C,[min:150],Max,,SIR,10,°C,[max:350],Step,,SIR,10,°C,[step:5],Default,,SIR,10,°C,[default:240]
+w,,BypassHysterese,BypassTempHyst,,,4080,30,,,SIR,10,°C,[min:0;max:50;step:5;default:20]
+r,,BypassHysterese,BypassTempHyst,,,4050,30,,,SIR,10,°C,,Min,,SIR,10,°C,[min:0],Max,,SIR,10,°C,[max:50],Step,,SIR,10,°C,[step:5],Default,,SIR,10,°C,[default:20]
+w,,Bypassbetrieb,BypassMode,,,4080,1b,,,UIR,0=Auto;1=Closed;2=Open,,[min:0;max:2;step:1;default:0]
+r,,Bypassbetrieb,BypassMode,,,4050,1b,,,UIR,0=Auto;1=Closed;2=Open,,,,,IGN:6,,,,Default,,UIR,0=Auto;1=Closed;2=Open,,[default:0] - min/max/step fields of enum message omitted
+w,,ZentralheizungWRG,CVWTWMode,,,4080,07,,,UIR,0=off;1=on,,[min:0;max:1;step:1;default:0]
+r,,ZentralheizungWRG,CVWTWMode,,,4050,07,,,UIR,0=off;1=on,,,,,IGN:6,,,,Default,,UIR,0=off;1=on,,[default:0] - min/max/step fields of enum message omitted
+w,,UngleichgewichtMöglich,UnbalanceMode,,,4080,08,,,UIR,0=Not Permitted;1=Permitted,,[min:0;max:1;step:1;default:1]
+r,,UngleichgewichtMöglich,UnbalanceMode,,,4050,08,,,UIR,0=Not Permitted;1=Permitted,,,,,IGN:6,,,,Default,,UIR,0=Not Permitted;1=Permitted,,[default:1] - min/max/step fields of enum message omitted
+w,,StändigesUngleichgewicht,UnbalanceFlow,,,4080,09,,,SIR,,m³/h,[min:-100;max:100;step:1;default:0]
+r,,StändigesUngleichgewicht,UnbalanceFlow,,,4050,09,,,SIR,,m³/h,,Min,,SIR,,m³/h,[min:-100],Max,,SIR,,m³/h,[max:100],Step,,SIR,,m³/h,[step:1],Default,,SIR,,m³/h,[default:0]
+w,,TypZusätslichesHeizregister,ExtraHeaterType,,,4080,0a,,,UIR,,,[min:0;max:2;step:1;default:0]
+r,,TypZusätslichesHeizregister,ExtraHeaterType,,,4050,0a,,,UIR,,,,Min,,UIR,,,[min:0],Max,,UIR,,,[max:2],Step,,UIR,,,[step:1],Default,,UIR,,,[default:0]
+w,,TemperaturNachheizregister,PostheaterTemp,,,4080,0b,,,SIR,10,°C,[min:150;max:300;step:5;default:210]
+r,,TemperaturNachheizregister,PostheaterTemp,,,4050,0b,,,SIR,10,°C,,Min,,SIR,10,°C,[min:150],Max,,SIR,10,°C,[max:300],Step,,SIR,10,°C,[step:5],Default,,SIR,10,°C,[default:210]
+w,,AuswahlEingang1,Input1Mode,,,4080,0c,,,UIR,0=Normally Closed;1=0-10V input;2=Normally Open;3=12V Bypass Open/0V Bypass Closed;4=0V Bypass Open/12V Bypass Closed,,[min:0;max:4;step:1;default:0]
+r,,AuswahlEingang1,Input1Mode,,,4050,0c,,,UIR,0=Normally Closed;1=0-10V input;2=Normally Open;3=12V Bypass Open/0V Bypass Closed;4=0V Bypass Open/12V Bypass Closed,,,,,IGN:6,,,,Default,,UIR,0=Normally Closed;1=0-10V input;2=Normally Open;3=12V Bypass Open/0V Bypass Closed;4=0V Bypass Open/12V Bypass Closed,,[default:0] - min/max/step fields of enum message omitted
+w,,MinimaleSpannungEingang1,Input1VMin,,,4080,0d,,,SIR,10,V,[min:0;max:100;step:5;default:0]
+r,,MinimaleSpannungEingang1,Input1VMin,,,4050,0d,,,SIR,10,V,,Min,,SIR,10,V,[min:0],Max,,SIR,10,V,[max:100],Step,,SIR,10,V,[step:5],Default,,SIR,10,V,[default:0]
+w,,MaximaleSpannungEingang1,Input1VMax,,,4080,0e,,,SIR,10,V,[min:0;max:100;step:5;default:100]
+r,,MaximaleSpannungEingang1,Input1VMax,,,4050,0e,,,SIR,10,V,,Min,,SIR,10,V,[min:0],Max,,SIR,10,V,[max:100],Step,,SIR,10,V,[step:5],Default,,SIR,10,V,[default:100]
+w,,BedingungenSchalteingang1,CN1Coupling,,,4080,0f,,,UIR,0=off;1=on;2=on if bypass open condition satisfied;3=bypass control;4=Bedroom valve,,[min:0;max:4;step:1;default:0]
+r,,BedingungenSchalteingang1,CN1Coupling,,,4050,0f,,,UIR,0=off;1=on;2=on if bypass open condition satisfied;3=bypass control;4=Bedroom valve,,,,,IGN:6,,,,Default,,UIR,0=off;1=on;2=on if bypass open condition satisfied;3=bypass control;4=Bedroom valve,,[default:0] - min/max/step fields of enum message omitted
+w,,FunktionZuluftventilatorEingang1,CN1Inlet,,,4080,10,,,UIR,0=FanOff;1=Minimal flow 50m³/h;2=FanMode1;3=FanMode2;4=FanMode3;5=ManualSwitch;6=MaximalFlow;7=FanNotActive,,[min:0;max:7;step:1;default:5]
+r,,FunktionZuluftventilatorEingang1,CN1Inlet,,,4050,10,,,UIR,0=FanOff;1=Minimal flow 50m³/h;2=FanMode1;3=FanMode2;4=FanMode3;5=ManualSwitch;6=MaximalFlow;7=FanNotActive,,,,,IGN:6,,,,Default,,UIR,0=FanOff;1=Minimal flow 50m³/h;2=FanMode1;3=FanMode2;4=FanMode3;5=ManualSwitch;6=MaximalFlow;7=FanNotActive,,[default:5] - min/max/step fields of enum message omitted
+w,,FunktionAbluftventilatorEingang1,CN1Exhaust,,,4080,11,,,UIR,0=FanOff;1=Minimal flow 50m³/h;2=FanMode1;3=FanMode2;4=FanMode3;5=ManualSwitch;6=MaximalFlow;7=FanNotActive,,[min:0;max:7;step:1;default:5]
+r,,FunktionAbluftventilatorEingang1,CN1Exhaust,,,4050,11,,,UIR,0=FanOff;1=Minimal flow 50m³/h;2=FanMode1;3=FanMode2;4=FanMode3;5=ManualSwitch;6=MaximalFlow;7=FanNotActive,,,,,IGN:6,,,,Default,,UIR,0=FanOff;1=Minimal flow 50m³/h;2=FanMode1;3=FanMode2;4=FanMode3;5=ManualSwitch;6=MaximalFlow;7=FanNotActive,,[default:5] - min/max/step fields of enum message omitted
+w,,AuswahlEingang2,Input2Mode,,,4080,12,,,UIR,0=Normally Closed;1=0-10V input;2=Normally Open;3=12V Bypass Open/0V Bypass Closed;4=0V Bypass Open/12V Bypass Closed,,[min:0;max:4;step:1;default:1]
+r,,AuswahlEingang2,Input2Mode,,,4050,12,,,UIR,0=Normally Closed;1=0-10V input;2=Normally Open;3=12V Bypass Open/0V Bypass Closed;4=0V Bypass Open/12V Bypass Closed,,,,,IGN:6,,,,Default,,UIR,0=Normally Closed;1=0-10V input;2=Normally Open;3=12V Bypass Open/0V Bypass Closed;4=0V Bypass Open/12V Bypass Closed,,[default:1] - min/max/step fields of enum message omitted
+w,,MinimaleSpannungEingang2,Input2VMin,,,4080,13,,,SIR,10,V,[min:0;max:100;step:5;default:0]
+r,,MinimaleSpannungEingang2,Input2VMin,,,4050,13,,,SIR,10,V,,Min,,SIR,10,V,[min:0],Max,,SIR,10,V,[max:100],Step,,SIR,10,V,[step:5],Default,,SIR,10,V,[default:0]
+w,,MaximaleSpannungEingang2,Input2VMax,,,4080,14,,,SIR,10,V,[min:0;max:100;step:5;default:100]
+r,,MaximaleSpannungEingang2,Input2VMax,,,4050,14,,,SIR,10,V,,Min,,SIR,10,V,[min:0],Max,,SIR,10,V,[max:100],Step,,SIR,10,V,[step:5],Default,,SIR,10,V,[default:100]
+w,,BedingungenSchalteingang2,CN2Coupling,,,4080,15,,,UIR,0=off;1=on;2=on if bypass open condition satisfied;3=bypass control;4=Bedroom valve,,[min:0;max:4;step:1;default:0]
+r,,BedingungenSchalteingang2,CN2Coupling,,,4050,15,,,UIR,0=off;1=on;2=on if bypass open condition satisfied;3=bypass control;4=Bedroom valve,,,,,IGN:6,,,,Default,,UIR,0=off;1=on;2=on if bypass open condition satisfied;3=bypass control;4=Bedroom valve,,[default:0] - min/max/step fields of enum message omitted
+w,,FunktionZuluftventilatorEingang2,CN2Inlet,,,4080,16,,,UIR,0=FanOff;1=Minimal flow 50m³/h;2=FanMode1;3=FanMode2;4=FanMode3;5=ManualSwitch;6=MaximalFlow;7=FanNotActive,,[min:0;max:7;step:1;default:5]
+r,,FunktionZuluftventilatorEingang2,CN2Inlet,,,4050,16,,,UIR,0=FanOff;1=Minimal flow 50m³/h;2=FanMode1;3=FanMode2;4=FanMode3;5=ManualSwitch;6=MaximalFlow;7=FanNotActive,,,,,IGN:6,,,,Default,,UIR,0=FanOff;1=Minimal flow 50m³/h;2=FanMode1;3=FanMode2;4=FanMode3;5=ManualSwitch;6=MaximalFlow;7=FanNotActive,,[default:5] - min/max/step fields of enum message omitted
+w,,FunktionAbluftventilatorEingang2,CN2Exhaust,,,4080,17,,,UIR,0=FanOff;1=Minimal flow 50m³/h;2=FanMode1;3=FanMode2;4=FanMode3;5=ManualSwitch;6=MaximalFlow;7=FanNotActive,,[min:0;max:7;step:1;default:5]
+r,,FunktionAbluftventilatorEingang2,CN2Exhaust,,,4050,17,,,UIR,0=FanOff;1=Minimal flow 50m³/h;2=FanMode1;3=FanMode2;4=FanMode3;5=ManualSwitch;6=MaximalFlow;7=FanNotActive,,,,,IGN:6,,,,Default,,UIR,0=FanOff;1=Minimal flow 50m³/h;2=FanMode1;3=FanMode2;4=FanMode3;5=ManualSwitch;6=MaximalFlow;7=FanNotActive,,[default:5] - min/max/step fields of enum message omitted
+w,,Erdreichwärmetauscher,EWTMode,,,4080,18,,,UIR,0=off;1=on,,[min:0;max:1;step:1;default:0]
+r,,Erdreichwärmetauscher,EWTMode,,,4050,18,,,UIR,0=off;1=on,,,,,IGN:6,,,,Default,,UIR,0=off;1=on,,[default:0] - min/max/step fields of enum message omitted
+w,,MinTempErdreichwärmetauscher,EWTTempMin,,,4080,19,,,SIR,10,°C,[min:0;max:100;step:5;default:50]
+r,,MinTempErdreichwärmetauscher,EWTTempMin,,,4050,19,,,SIR,10,°C,,Min,,SIR,10,°C,[min:0],Max,,SIR,10,°C,[max:100],Step,,SIR,10,°C,[step:5],Default,,SIR,10,°C,[default:50]
+w,,MaxTempErdreichwärmetauscher,EWTTempMax,,,4080,1a,,,SIR,10,°C,[min:150;max:400;step:5;default:250]
+r,,MaxTempErdreichwärmetauscher,EWTTempMax,,,4050,1a,,,SIR,10,°C,,Min,,SIR,10,°C,[min:150],Max,,SIR,10,°C,[max:400],Step,,SIR,10,°C,[step:5],Default,,SIR,10,°C,[default:250]
+w,,FeuchtesensorVorhanden,RHTSensorPresent,,,4080,32,,,UIR,,,[min:0;max:1;step:1;default:0]
+r,,FeuchtesensorVorhanden,RHTSensorPresent,,,4050,32,,,UIR,,,,Min,,UIR,,,[min:0],Max,,UIR,,,[max:1],Step,,UIR,,,[step:1],Default,,UIR,,,[default:0]
+w,,EmpfindlichkeitFeuchtesensor,RHTSensorSensitivity,,,4080,33,,,SIR,,,[min:-2;max:2;step:1;default:0]
+r,,EmpfindlichkeitFeuchtesensor,RHTSensorSensitivity,,,4050,33,,,SIR,,,,Min,,SIR,,,[min:-2],Max,,SIR,,,[max:2],Step,,SIR,,,[step:1],Default,,SIR,,,[default:0]
+w,,BeleuchtungDisplay,BacklightLevel,,,4080,1d,,,UIR,,%,[min:0;max:100;step:5;default:10]
+r,,BeleuchtungDisplay,BacklightLevel,,,4050,1d,,,UIR,,%,,Min,,UIR,,%,[min:0],Max,,UIR,,%,[max:100],Step,,UIR,,%,[step:5],Default,,UIR,,%,[default:10]
+w,,CO2Sensor1UntererGrenzwert,CO2Sensor1LowerLimit,,,4080,34,,,UIR,,ppm,[min:400;max:2000;step:25;default:400]
+r,,CO2Sensor1UntererGrenzwert,CO2Sensor1LowerLimit,,,4050,34,,,UIR,,ppm,,Min,,UIR,,ppm,[min:400],Max,,UIR,,ppm,[max:2000],Step,,UIR,,ppm,[step:25],Default,,UIR,,ppm,[default:400]
+w,,CO2Sensor1ObererGrenzwert,CO2Sensor1UpperLimit,,,4080,35,,,UIR,,ppm,[min:400;max:2000;step:25;default:1200]
+r,,CO2Sensor1ObererGrenzwert,CO2Sensor1UpperLimit,,,4050,35,,,UIR,,ppm,,Min,,UIR,,ppm,[min:400],Max,,UIR,,ppm,[max:2000],Step,,UIR,,ppm,[step:25],Default,,UIR,,ppm,[default:1200]
+w,,CO2Sensor2UntererGrenzwert,CO2Sensor2LowerLimit,,,4080,36,,,UIR,,ppm,[min:400;max:2000;step:25;default:400]
+r,,CO2Sensor2UntererGrenzwert,CO2Sensor2LowerLimit,,,4050,36,,,UIR,,ppm,,Min,,UIR,,ppm,[min:400],Max,,UIR,,ppm,[max:2000],Step,,UIR,,ppm,[step:25],Default,,UIR,,ppm,[default:400]
+w,,CO2Sensor2ObererGrenzwert,CO2Sensor2UpperLimit,,,4080,37,,,UIR,,ppm,[min:400;max:2000;step:25;default:1200]
+r,,CO2Sensor2ObererGrenzwert,CO2Sensor2UpperLimit,,,4050,37,,,UIR,,ppm,,Min,,UIR,,ppm,[min:400],Max,,UIR,,ppm,[max:2000],Step,,UIR,,ppm,[step:25],Default,,UIR,,ppm,[default:1200]
+w,,CO2Sensor3UntererGrenzwert,CO2Sensor3LowerLimit,,,4080,38,,,UIR,,ppm,[min:400;max:2000;step:25;default:400]
+r,,CO2Sensor3UntererGrenzwert,CO2Sensor3LowerLimit,,,4050,38,,,UIR,,ppm,,Min,,UIR,,ppm,[min:400],Max,,UIR,,ppm,[max:2000],Step,,UIR,,ppm,[step:25],Default,,UIR,,ppm,[default:400]
+w,,CO2Sensor3ObererGrenzwert,CO2Sensor3UpperLimit,,,4080,39,,,UIR,,ppm,[min:400;max:2000;step:25;default:1200]
+r,,CO2Sensor3ObererGrenzwert,CO2Sensor3UpperLimit,,,4050,39,,,UIR,,ppm,,Min,,UIR,,ppm,[min:400],Max,,UIR,,ppm,[max:2000],Step,,UIR,,ppm,[step:25],Default,,UIR,,ppm,[default:1200]
+w,,CO2Sensor4UntererGrenzwert,CO2Sensor4LowerLimit,,,4080,3a,,,UIR,,ppm,[min:400;max:2000;step:25;default:400]
+r,,CO2Sensor4UntererGrenzwert,CO2Sensor4LowerLimit,,,4050,3a,,,UIR,,ppm,,Min,,UIR,,ppm,[min:400],Max,,UIR,,ppm,[max:2000],Step,,UIR,,ppm,[step:25],Default,,UIR,,ppm,[default:400]
+w,,CO2Sensor4ObererGrenzwert,CO2Sensor4UpperLimit,,,4080,3b,,,UIR,,ppm,[min:400;max:2000;step:25;default:1200]
+r,,CO2Sensor4ObererGrenzwert,CO2Sensor4UpperLimit,,,4050,3b,,,UIR,,ppm,,Min,,UIR,,ppm,[min:400],Max,,UIR,,ppm,[max:2000],Step,,UIR,,ppm,[step:25],Default,,UIR,,ppm,[default:1200]
+w,,CO2SensorenAktiviert,CO2SensorsActivated,,,4080,3c,,,UIR,0=no;1=yes,,[min:0;max:1;step:1;default:0]
+r,,CO2SensorenAktiviert,CO2SensorsActivated,,,4050,3c,,,UIR,0=no;1=yes,,,,,IGN:6,,,,Default,,UIR,0=no;1=yes,,[default:0] - min/max/step fields of enum message omitted
+w,,Durchsatzkorrektur,FlowCorrection,,,4080,3f,,,UIR,,%,[min:90;max:110;step:1;default:100]
+r,,Durchsatzkorrektur,FlowCorrection,,,4050,3f,,,UIR,,%,,Min,,UIR,,%,[min:90],Max,,UIR,,%,[max:110],Step,,UIR,,%,[step:1],Default,,UIR,,%,[default:100]
+w,,Schaltergrundstellung,SwitchDefaultPos,,,4080,40,,,UIR,0=off;1=on,,[min:0;max:1;step:1;default:1]
+r,,Schaltergrundstellung,SwitchDefaultPos,,,4050,40,,,UIR,0=off;1=on,,,,,IGN:6,,,,Default,,UIR,0=off;1=on,,[default:1] - min/max/step fields of enum message omitted
+w,,TageVorFilterwarnung,FilterDaysBeforeWarning,,,4080,45,,,UIR,,,[min:1;max:365;step:1;default:90]
+r,,TageVorFilterwarnung,FilterDaysBeforeWarning,,,4050,45,,,UIR,,,,Min,,UIR,,,[min:1],Max,,UIR,,,[max:365],Step,,UIR,,,[step:1],Default,,UIR,,,[default:90]
+w,,SchnittstelleModbus,ModbusInterface,,,4080,41,,,UIR,,,[min:0;max:3;step:2;default:1]
+r,,SchnittstelleModbus,ModbusInterface,,,4050,41,,,UIR,,,,Min,,UIR,,,[min:0],Max,,UIR,,,[max:3],Step,,UIR,,,[step:2],Default,,UIR,,,[default:1]
+w,,AdresseModbusSlave,ModbusSlaveAddress,,,4080,42,,,UIR,,,[min:1;max:247;step:1;default:11]
+r,,AdresseModbusSlave,ModbusSlaveAddress,,,4050,42,,,UIR,,,,Min,,UIR,,,[min:1],Max,,UIR,,,[max:247],Step,,UIR,,,[step:1],Default,,UIR,,,[default:11]
+w,,GeschwindigkeitModbus,ModbusSpeed,,,4080,43,,,UIR,0=1200 Baud;1=2400 Baud;2=4800 Baud;3=9600 Baud;4=19k2 Baud;5=38k4 Baud;6=56k Baud;7=115k Baud,,[min:0;max:7;step:1;default:3]
+r,,GeschwindigkeitModbus,ModbusSpeed,,,4050,43,,,UIR,0=1200 Baud;1=2400 Baud;2=4800 Baud;3=9600 Baud;4=19k2 Baud;5=38k4 Baud;6=56k Baud;7=115k Baud,,,,,IGN:6,,,,Default,,UIR,0=1200 Baud;1=2400 Baud;2=4800 Baud;3=9600 Baud;4=19k2 Baud;5=38k4 Baud;6=56k Baud;7=115k Baud,,[default:3] - min/max/step fields of enum message omitted
+w,,ParitätModbus,ModbusParity,,,4080,44,,,UIR,0=No Parity;1=Even Parity;2=Odd Parity;3=Unknown,,[min:0;max:3;step:1;default:1]
+r,,ParitätModbus,ModbusParity,,,4050,44,,,UIR,0=No Parity;1=Even Parity;2=Odd Parity;3=Unknown,,,,,IGN:6,,,,Default,,UIR,0=No Parity;1=Even Parity;2=Odd Parity;3=Unknown,,[default:1] - min/max/step fields of enum message omitted

--- a/7c.renovent-excellent-400-english.csv
+++ b/7c.renovent-excellent-400-english.csv
@@ -5,31 +5,33 @@
 ## - Brink Service Tool (decompiled via Jetbrains DotPeak): https://www.brinkclimatesystems.nl/tools/software-brink-service-tool-en
 ## - Renovent 150 Datasheet: https://manuals.plus/brink/renovent-sky-150-plus-mechanical-ventilation-with-heat-recovery-manual
 ## - Modbus Module Datasheet: https://www.brinkclimatesystems.nl/documenten/modbus-uwa2-b-uwa2-e-installation-regulations-614882.pdf
-##
-## For ebusd-configuration files for complete portfolio of Brink HRU units go to https://github.com/pvyleta/ebusd-brink-hru
+## Message names are based on official Brink Service Tool translations with removed spaces and special characters. 
+## Message comment is the name of the parameter as used internally in code (as to help if the translation itself is confusing)
+## 
+## For ebusd configuration files for the complete Brink portfolio go to https://github.com/pvyleta/ebusd-brink-hru
 
 *r,Excellent400,,,,7c,
 *w,Excellent400,,,,7c,
 
 ## COMMON HRU COMMANDS ## (WTWCommands.cs - Some of them might not be applicable for this device, use with caution)
-w,,FactoryReset,,,,40ff,466163746f72795265736574
-w,,ResetNotifications,,,,4091,,,,UIR,0x0001=Errors;0x0100=Filter;0x0101=ErrorsAndFilter;0x0000=NoResetRequested,,NoResetRequested is a dummy message doing nothing. It might be useful for integration in MQTT and HA automation.
-r,,RequestErrorList,,,,4090,,,,HEX:18,,,
-w,,FanMode,,,,40a1,,,,ULR,0x0=Holiday;0x00010001=Reduced;0x00020002=Normal;0x00030003=High,,
-r,,FilterNotificationFlow,,,,4050,1c,,,UIR,-1000,m³,,Min,,UIR,-1000,m³,,Max,,UIR,-1000,m³,,Step,,UIR,-1000,m³,,Default,,UIR,-1000,m³,
-r,,TotalFilterDays,,,,4050,22,,,UIR,,Days,,Min,,UIR,,Days,,Max,,UIR,,Days,,Step,,UIR,,Days,,Default,,UIR,,Days,
-r,,TotalFilterFlow,,,,4050,23,,,UIR,-1000,m³,,Min,,UIR,-1000,m³,,Max,,UIR,-1000,m³,,Step,,UIR,-1000,m³,,Default,,UIR,-1000,m³,
-r,,TotalOperatingHours,,,,4050,24,,,UIR,-5,Hours,,Min,,UIR,-5,Hours,,Max,,UIR,-5,Hours,,Step,,UIR,-5,Hours,,Default,,UIR,-5,Hours,
-r,,TotalFlow,,,,4050,25,,,UIR,-1000,m³,,Min,,UIR,-1000,m³,,Max,,UIR,-1000,m³,,Step,,UIR,-1000,m³,,Default,,UIR,-1000,m³,
+w,,FactoryReset,FactoryReset,,,40ff,466163746f72795265736574
+w,,ResetNotifications,ResetNotifications,,,4091,,,,UIR,0x0001=Errors;0x0100=Filter;0x0101=ErrorsAndFilter;0x0000=NoResetRequested,,NoResetRequested is a dummy message doing nothing. It might be useful for integration in MQTT and HA automation.
+r,,ErrorHistory,RequestErrorList,,,4090,,,,HEX:18,,,
+w,,FanMode,FanMode,,,40a1,,,,ULR,0x0=Holiday;0x00010001=Reduced;0x00020002=Normal;0x00030003=High,,
+r,,FilterMaximumFlow,FilterNotificationFlow,,,4050,1c,,,UIR,-1000,m³,,Min,,UIR,-1000,m³,,Max,,UIR,-1000,m³,,Step,,UIR,-1000,m³,,Default,,UIR,-1000,m³,
+r,,FilterUsageDays,TotalFilterDays,,,4050,22,,,UIR,,Days,,Min,,UIR,,Days,,Max,,UIR,,Days,,Step,,UIR,,Days,,Default,,UIR,,Days,
+r,,FilterUsage,TotalFilterFlow,,,4050,23,,,UIR,-1000,m³,,Min,,UIR,-1000,m³,,Max,,UIR,-1000,m³,,Step,,UIR,-1000,m³,,Default,,UIR,-1000,m³,
+r,,OperatingTime,TotalOperatingHours,,,4050,24,,,UIR,-5,Hours,,Min,,UIR,-5,Hours,,Max,,UIR,-5,Hours,,Step,,UIR,-5,Hours,,Default,,UIR,-5,Hours,
+r,,TotalFlow1000m3,TotalFlow,,,4050,25,,,UIR,-1000,m³,,Min,,UIR,-1000,m³,,Max,,UIR,-1000,m³,,Step,,UIR,-1000,m³,,Default,,UIR,-1000,m³,
 
 ## Curent state and sensors ##
 r,,FanMode,FanMode,,,4022,01,,,UIR,0=Holiday;1=Reduced;2=Normal;3=High;4=Auto,,
-r,,SettingInletFlow,InletFlowSetting,,,4022,09,,,UIR,,m³/h,
-r,,SettingExhaustFlow,ExhaustFlowSetting,,,4022,0a,,,UIR,,m³/h,
-r,,InletFlow,ActualInletFlow,,,4022,0b,,,UIR,,m³/h,
-r,,ExhaustFlow,ActualExhaustFlow,,,4022,0c,,,UIR,,m³/h,
-r,,InletFanSpeed,ActualInletfanSpeed,,,4022,02,,,UIR,,rpm,
-r,,ExhaustFanSpeed,ActualExhaustfanSpeed,,,4022,03,,,UIR,,rpm,
+r,,InletFlowSetting,SettingInletFlow,,,4022,09,,,UIR,,m³/h,
+r,,ExhaustFlowSetting,SettingExhaustFlow,,,4022,0a,,,UIR,,m³/h,
+r,,ActualInletFlow,InletFlow,,,4022,0b,,,UIR,,m³/h,
+r,,ActualExhaustFlow,ExhaustFlow,,,4022,0c,,,UIR,,m³/h,
+r,,ActualInletfanSpeed,InletFanSpeed,,,4022,02,,,UIR,,rpm,
+r,,ActualExhaustfanSpeed,ExhaustFanSpeed,,,4022,03,,,UIR,,rpm,
 r,,PerilexPosition,PerilexPosition,,,4022,05,,,UIR,0=Position_0;1=Position_1;2=Position_2;3=Position_3;,,
 r,,SwitchPosition,SwitchPosition,,,4022,06,,,UIR,0=Position_0;1=Position_1;2=Position_2;3=Position_3;,,
 r,,Contact1Position,Contact1Position,,,4022,1b,,,UIR,0=Off;1=On,,
@@ -48,80 +50,80 @@ r,,FanStatus,FanStatus,,,4022,11,,,UIR,0=Initializing;1=ConstantFlow;2=ConstantP
 r,,InsideTemperature,InsideTemperature,,,4022,07,,,SIR,10,°C,
 r,,OutsideTemperature,OutsideTemperature,,,4022,08,,,SIR,10,°C,
 r,,OptionTemperature,OptionTemperature,,,4022,1a,,,SIR,10,°C,
-r,,FilterStatus,FilterNotification,,,4022,18,,,UIR,0=Clean;1=Dirty,,
+r,,FilterNotification,FilterStatus,,,4022,18,,,UIR,0=Clean;1=Dirty,,
 r,,RelativeHumidity,RelativeHumidity,,,4022,20,,,SIR,10,%,
 r,,HumidityBoostState,HumidityBoostState,,,4022,21,,,UIR,0=Error;1=NotInitialized;2=SensorNotActive;3=PowerUpDelay;4=NormalRH;5=BoostRising;6=BoostStable;7=BoostDecending;8=BoostRHLowLevelStable,Pa,
-r,,PressureInlet,ActualInletPressure,,,4022,14,,,UIR,10,Pa,
-r,,PressureExhaust,ActualExhaustPressure,,,4022,15,,,UIR,10,Pa,
-r,,EBusSyncGenErrorCount,EBusSyncGenErrors,,,4022,64,,,UIR,,,
+r,,ActualInletPressure,PressureInlet,,,4022,14,,,UIR,10,Pa,
+r,,ActualExhaustPressure,PressureExhaust,,,4022,15,,,UIR,10,Pa,
+r,,EBusSyncGenErrors,EBusSyncGenErrorCount,,,4022,64,,,UIR,,,
 r,,CO2Sensor1Status,CO2Sensor1Status,,,4022,28,,,UIR,0=Error;1=NotInitialized;2=Idle;3=WarmingUp;4=Running;5=Calibrating;6=SelfTest,,
-r,,CO2Sensor1Value,CO2Sensor1Value,,,4022,29,,,UIR,,ppm,
+r,,CO2Sensor1Level,CO2Sensor1Value,,,4022,29,,,UIR,,ppm,
 r,,CO2Sensor2Status,CO2Sensor2Status,,,4022,2a,,,UIR,0=Error;1=NotInitialized;2=Idle;3=WarmingUp;4=Running;5=Calibrating;6=SelfTest,,
-r,,CO2Sensor2Value,CO2Sensor2Value,,,4022,2b,,,UIR,,ppm,
+r,,CO2Sensor2Level,CO2Sensor2Value,,,4022,2b,,,UIR,,ppm,
 r,,CO2Sensor3Status,CO2Sensor3Status,,,4022,2c,,,UIR,0=Error;1=NotInitialized;2=Idle;3=WarmingUp;4=Running;5=Calibrating;6=SelfTest,,
-r,,CO2Sensor3Value,CO2Sensor3Value,,,4022,2d,,,UIR,,ppm,
+r,,CO2Sensor3Level,CO2Sensor3Value,,,4022,2d,,,UIR,,ppm,
 r,,CO2Sensor4Status,CO2Sensor4Status,,,4022,2e,,,UIR,0=Error;1=NotInitialized;2=Idle;3=WarmingUp;4=Running;5=Calibrating;6=SelfTest,,
-r,,CO2Sensor4Value,CO2Sensor4Value,,,4022,2f,,,UIR,,ppm,
+r,,CO2Sensor4Level,CO2Sensor4Value,,,4022,2f,,,UIR,,ppm,
 
-## Configuration parameters ##
-w,,FlowMode0,FlowMode0,,,4080,21,,,SIR,,m³/h,[min:0;max:50;step:50;default:50]
-r,,FlowMode0,FlowMode0,,,4050,21,,,SIR,,m³/h,,Min,,SIR,,m³/h,[min:0],Max,,SIR,,m³/h,[max:50],Step,,SIR,,m³/h,[step:50],Default,,SIR,,m³/h,[default:50]
-w,,FlowMode1,FlowMode1,,,4080,01,,,SIR,,m³/h,[min:50;max:400;step:5;default:100]
-r,,FlowMode1,FlowMode1,,,4050,01,,,SIR,,m³/h,,Min,,SIR,,m³/h,[min:50],Max,,SIR,,m³/h,[max:400],Step,,SIR,,m³/h,[step:5],Default,,SIR,,m³/h,[default:100]
-w,,FlowMode2,FlowMode2,,,4080,02,,,SIR,,m³/h,[min:50;max:400;step:5;default:200]
-r,,FlowMode2,FlowMode2,,,4050,02,,,SIR,,m³/h,,Min,,SIR,,m³/h,[min:50],Max,,SIR,,m³/h,[max:400],Step,,SIR,,m³/h,[step:5],Default,,SIR,,m³/h,[default:200]
-w,,FlowMode3,FlowMode3,,,4080,03,,,SIR,,m³/h,[min:50;max:400;step:5;default:300]
-r,,FlowMode3,FlowMode3,,,4050,03,,,SIR,,m³/h,,Min,,SIR,,m³/h,[min:50],Max,,SIR,,m³/h,[max:400],Step,,SIR,,m³/h,[step:5],Default,,SIR,,m³/h,[default:300]
-w,,BypassTemp,BypassTemp,,,4080,04,,,SIR,10,°C,[min:150;max:350;step:5;default:240]
-r,,BypassTemp,BypassTemp,,,4050,04,,,SIR,10,°C,,Min,,SIR,10,°C,[min:150],Max,,SIR,10,°C,[max:350],Step,,SIR,10,°C,[step:5],Default,,SIR,10,°C,[default:240]
-w,,BypassTempHyst,BypassTempHyst,,,4080,30,,,SIR,10,°C,[min:0;max:50;step:5;default:20]
-r,,BypassTempHyst,BypassTempHyst,,,4050,30,,,SIR,10,°C,,Min,,SIR,10,°C,[min:0],Max,,SIR,10,°C,[max:50],Step,,SIR,10,°C,[step:5],Default,,SIR,10,°C,[default:20]
-w,,BypassMode,BypassMode,,,4080,1b,,,UIR,0=Auto;1=Closed;2=Open,,[min:0;max:2;step:1;default:0]
-r,,BypassMode,BypassMode,,,4050,1b,,,UIR,0=Auto;1=Closed;2=Open,,,,,IGN:6,,,,Default,,UIR,0=Auto;1=Closed;2=Open,,[default:0] - min/max/step fields of enum message omitted
-w,,CVWTWMode,CVWTWMode,,,4080,07,,,UIR,0=off;1=on,,[min:0;max:1;step:1;default:0]
-r,,CVWTWMode,CVWTWMode,,,4050,07,,,UIR,0=off;1=on,,,,,IGN:6,,,,Default,,UIR,0=off;1=on,,[default:0] - min/max/step fields of enum message omitted
-w,,UnbalanceMode,UnbalanceMode,,,4080,08,,,UIR,0=Not Permitted;1=Permitted,,[min:0;max:1;step:1;default:1]
-r,,UnbalanceMode,UnbalanceMode,,,4050,08,,,UIR,0=Not Permitted;1=Permitted,,,,,IGN:6,,,,Default,,UIR,0=Not Permitted;1=Permitted,,[default:1] - min/max/step fields of enum message omitted
-w,,UnbalanceFlow,UnbalanceFlow,,,4080,09,,,SIR,,m³/h,[min:-100;max:100;step:1;default:0]
-r,,UnbalanceFlow,UnbalanceFlow,,,4050,09,,,SIR,,m³/h,,Min,,SIR,,m³/h,[min:-100],Max,,SIR,,m³/h,[max:100],Step,,SIR,,m³/h,[step:1],Default,,SIR,,m³/h,[default:0]
+## Configuration parameters ## (values in brackets next to field are definitions of those fields values from Brink Service Tool.)
+w,,AirFlowRateMode0,FlowMode0,,,4080,21,,,SIR,,m³/h,[min:0;max:50;step:50;default:50]
+r,,AirFlowRateMode0,FlowMode0,,,4050,21,,,SIR,,m³/h,,Min,,SIR,,m³/h,[min:0],Max,,SIR,,m³/h,[max:50],Step,,SIR,,m³/h,[step:50],Default,,SIR,,m³/h,[default:50]
+w,,AirFlowRateMode1,FlowMode1,,,4080,01,,,SIR,,m³/h,[min:50;max:400;step:5;default:100]
+r,,AirFlowRateMode1,FlowMode1,,,4050,01,,,SIR,,m³/h,,Min,,SIR,,m³/h,[min:50],Max,,SIR,,m³/h,[max:400],Step,,SIR,,m³/h,[step:5],Default,,SIR,,m³/h,[default:100]
+w,,AirFlowRateMode2,FlowMode2,,,4080,02,,,SIR,,m³/h,[min:50;max:400;step:5;default:200]
+r,,AirFlowRateMode2,FlowMode2,,,4050,02,,,SIR,,m³/h,,Min,,SIR,,m³/h,[min:50],Max,,SIR,,m³/h,[max:400],Step,,SIR,,m³/h,[step:5],Default,,SIR,,m³/h,[default:200]
+w,,AirFlowRateMode3,FlowMode3,,,4080,03,,,SIR,,m³/h,[min:50;max:400;step:5;default:300]
+r,,AirFlowRateMode3,FlowMode3,,,4050,03,,,SIR,,m³/h,,Min,,SIR,,m³/h,[min:50],Max,,SIR,,m³/h,[max:400],Step,,SIR,,m³/h,[step:5],Default,,SIR,,m³/h,[default:300]
+w,,BypassTemperature,BypassTemp,,,4080,04,,,SIR,10,°C,[min:150;max:350;step:5;default:240]
+r,,BypassTemperature,BypassTemp,,,4050,04,,,SIR,10,°C,,Min,,SIR,10,°C,[min:150],Max,,SIR,10,°C,[max:350],Step,,SIR,10,°C,[step:5],Default,,SIR,10,°C,[default:240]
+w,,BypassHysteresis,BypassTempHyst,,,4080,30,,,SIR,10,°C,[min:0;max:50;step:5;default:20]
+r,,BypassHysteresis,BypassTempHyst,,,4050,30,,,SIR,10,°C,,Min,,SIR,10,°C,[min:0],Max,,SIR,10,°C,[max:50],Step,,SIR,10,°C,[step:5],Default,,SIR,10,°C,[default:20]
+w,,OperationBypassValve,BypassMode,,,4080,1b,,,UIR,0=Auto;1=Closed;2=Open,,[min:0;max:2;step:1;default:0]
+r,,OperationBypassValve,BypassMode,,,4050,1b,,,UIR,0=Auto;1=Closed;2=Open,,,,,IGN:6,,,,Default,,UIR,0=Auto;1=Closed;2=Open,,[default:0] - min/max/step fields of enum message omitted
+w,,CentralHeatingHeatRecovery,CVWTWMode,,,4080,07,,,UIR,0=off;1=on,,[min:0;max:1;step:1;default:0]
+r,,CentralHeatingHeatRecovery,CVWTWMode,,,4050,07,,,UIR,0=off;1=on,,,,,IGN:6,,,,Default,,UIR,0=off;1=on,,[default:0] - min/max/step fields of enum message omitted
+w,,ImbalancePermissible,UnbalanceMode,,,4080,08,,,UIR,0=Not Permitted;1=Permitted,,[min:0;max:1;step:1;default:1]
+r,,ImbalancePermissible,UnbalanceMode,,,4050,08,,,UIR,0=Not Permitted;1=Permitted,,,,,IGN:6,,,,Default,,UIR,0=Not Permitted;1=Permitted,,[default:1] - min/max/step fields of enum message omitted
+w,,FixedImbalance,UnbalanceFlow,,,4080,09,,,SIR,,m³/h,[min:-100;max:100;step:1;default:0]
+r,,FixedImbalance,UnbalanceFlow,,,4050,09,,,SIR,,m³/h,,Min,,SIR,,m³/h,[min:-100],Max,,SIR,,m³/h,[max:100],Step,,SIR,,m³/h,[step:1],Default,,SIR,,m³/h,[default:0]
 w,,ExtraHeaterType,ExtraHeaterType,,,4080,0a,,,UIR,,,[min:0;max:2;step:1;default:0]
 r,,ExtraHeaterType,ExtraHeaterType,,,4050,0a,,,UIR,,,,Min,,UIR,,,[min:0],Max,,UIR,,,[max:2],Step,,UIR,,,[step:1],Default,,UIR,,,[default:0]
-w,,PostheaterTemp,PostheaterTemp,,,4080,0b,,,SIR,10,°C,[min:150;max:300;step:5;default:210]
-r,,PostheaterTemp,PostheaterTemp,,,4050,0b,,,SIR,10,°C,,Min,,SIR,10,°C,[min:150],Max,,SIR,10,°C,[max:300],Step,,SIR,10,°C,[step:5],Default,,SIR,10,°C,[default:210]
-w,,Input1Mode,Input1Mode,,,4080,0c,,,UIR,0=Normally Closed;1=0-10V input;2=Normally Open;3=12V Bypass Open/0V Bypass Closed;4=0V Bypass Open/12V Bypass Closed,,[min:0;max:4;step:1;default:0]
-r,,Input1Mode,Input1Mode,,,4050,0c,,,UIR,0=Normally Closed;1=0-10V input;2=Normally Open;3=12V Bypass Open/0V Bypass Closed;4=0V Bypass Open/12V Bypass Closed,,,,,IGN:6,,,,Default,,UIR,0=Normally Closed;1=0-10V input;2=Normally Open;3=12V Bypass Open/0V Bypass Closed;4=0V Bypass Open/12V Bypass Closed,,[default:0] - min/max/step fields of enum message omitted
-w,,Input1VMin,Input1VMin,,,4080,0d,,,SIR,10,V,[min:0;max:100;step:5;default:0]
-r,,Input1VMin,Input1VMin,,,4050,0d,,,SIR,10,V,,Min,,SIR,10,V,[min:0],Max,,SIR,10,V,[max:100],Step,,SIR,10,V,[step:5],Default,,SIR,10,V,[default:0]
-w,,Input1VMax,Input1VMax,,,4080,0e,,,SIR,10,V,[min:0;max:100;step:5;default:100]
-r,,Input1VMax,Input1VMax,,,4050,0e,,,SIR,10,V,,Min,,SIR,10,V,[min:0],Max,,SIR,10,V,[max:100],Step,,SIR,10,V,[step:5],Default,,SIR,10,V,[default:100]
-w,,CN1Coupling,CN1Coupling,,,4080,0f,,,UIR,0=off;1=on;2=on if bypass open condition satisfied;3=bypass control;4=Bedroom valve,,[min:0;max:4;step:1;default:0]
-r,,CN1Coupling,CN1Coupling,,,4050,0f,,,UIR,0=off;1=on;2=on if bypass open condition satisfied;3=bypass control;4=Bedroom valve,,,,,IGN:6,,,,Default,,UIR,0=off;1=on;2=on if bypass open condition satisfied;3=bypass control;4=Bedroom valve,,[default:0] - min/max/step fields of enum message omitted
-w,,CN1Inlet,CN1Inlet,,,4080,10,,,UIR,0=FanOff;1=Minimal flow 50m³/h;2=FanMode1;3=FanMode2;4=FanMode3;5=ManualSwitch;6=MaximalFlow;7=FanNotActive,,[min:0;max:7;step:1;default:5]
-r,,CN1Inlet,CN1Inlet,,,4050,10,,,UIR,0=FanOff;1=Minimal flow 50m³/h;2=FanMode1;3=FanMode2;4=FanMode3;5=ManualSwitch;6=MaximalFlow;7=FanNotActive,,,,,IGN:6,,,,Default,,UIR,0=FanOff;1=Minimal flow 50m³/h;2=FanMode1;3=FanMode2;4=FanMode3;5=ManualSwitch;6=MaximalFlow;7=FanNotActive,,[default:5] - min/max/step fields of enum message omitted
-w,,CN1Exhaust,CN1Exhaust,,,4080,11,,,UIR,0=FanOff;1=Minimal flow 50m³/h;2=FanMode1;3=FanMode2;4=FanMode3;5=ManualSwitch;6=MaximalFlow;7=FanNotActive,,[min:0;max:7;step:1;default:5]
-r,,CN1Exhaust,CN1Exhaust,,,4050,11,,,UIR,0=FanOff;1=Minimal flow 50m³/h;2=FanMode1;3=FanMode2;4=FanMode3;5=ManualSwitch;6=MaximalFlow;7=FanNotActive,,,,,IGN:6,,,,Default,,UIR,0=FanOff;1=Minimal flow 50m³/h;2=FanMode1;3=FanMode2;4=FanMode3;5=ManualSwitch;6=MaximalFlow;7=FanNotActive,,[default:5] - min/max/step fields of enum message omitted
-w,,Input2Mode,Input2Mode,,,4080,12,,,UIR,0=Normally Closed;1=0-10V input;2=Normally Open;3=12V Bypass Open/0V Bypass Closed;4=0V Bypass Open/12V Bypass Closed,,[min:0;max:4;step:1;default:1]
-r,,Input2Mode,Input2Mode,,,4050,12,,,UIR,0=Normally Closed;1=0-10V input;2=Normally Open;3=12V Bypass Open/0V Bypass Closed;4=0V Bypass Open/12V Bypass Closed,,,,,IGN:6,,,,Default,,UIR,0=Normally Closed;1=0-10V input;2=Normally Open;3=12V Bypass Open/0V Bypass Closed;4=0V Bypass Open/12V Bypass Closed,,[default:1] - min/max/step fields of enum message omitted
-w,,Input2VMin,Input2VMin,,,4080,13,,,SIR,10,V,[min:0;max:100;step:5;default:0]
-r,,Input2VMin,Input2VMin,,,4050,13,,,SIR,10,V,,Min,,SIR,10,V,[min:0],Max,,SIR,10,V,[max:100],Step,,SIR,10,V,[step:5],Default,,SIR,10,V,[default:0]
-w,,Input2VMax,Input2VMax,,,4080,14,,,SIR,10,V,[min:0;max:100;step:5;default:100]
-r,,Input2VMax,Input2VMax,,,4050,14,,,SIR,10,V,,Min,,SIR,10,V,[min:0],Max,,SIR,10,V,[max:100],Step,,SIR,10,V,[step:5],Default,,SIR,10,V,[default:100]
-w,,CN2Coupling,CN2Coupling,,,4080,15,,,UIR,0=off;1=on;2=on if bypass open condition satisfied;3=bypass control;4=Bedroom valve,,[min:0;max:4;step:1;default:0]
-r,,CN2Coupling,CN2Coupling,,,4050,15,,,UIR,0=off;1=on;2=on if bypass open condition satisfied;3=bypass control;4=Bedroom valve,,,,,IGN:6,,,,Default,,UIR,0=off;1=on;2=on if bypass open condition satisfied;3=bypass control;4=Bedroom valve,,[default:0] - min/max/step fields of enum message omitted
-w,,CN2Inlet,CN2Inlet,,,4080,16,,,UIR,0=FanOff;1=Minimal flow 50m³/h;2=FanMode1;3=FanMode2;4=FanMode3;5=ManualSwitch;6=MaximalFlow;7=FanNotActive,,[min:0;max:7;step:1;default:5]
-r,,CN2Inlet,CN2Inlet,,,4050,16,,,UIR,0=FanOff;1=Minimal flow 50m³/h;2=FanMode1;3=FanMode2;4=FanMode3;5=ManualSwitch;6=MaximalFlow;7=FanNotActive,,,,,IGN:6,,,,Default,,UIR,0=FanOff;1=Minimal flow 50m³/h;2=FanMode1;3=FanMode2;4=FanMode3;5=ManualSwitch;6=MaximalFlow;7=FanNotActive,,[default:5] - min/max/step fields of enum message omitted
-w,,CN2Exhaust,CN2Exhaust,,,4080,17,,,UIR,0=FanOff;1=Minimal flow 50m³/h;2=FanMode1;3=FanMode2;4=FanMode3;5=ManualSwitch;6=MaximalFlow;7=FanNotActive,,[min:0;max:7;step:1;default:5]
-r,,CN2Exhaust,CN2Exhaust,,,4050,17,,,UIR,0=FanOff;1=Minimal flow 50m³/h;2=FanMode1;3=FanMode2;4=FanMode3;5=ManualSwitch;6=MaximalFlow;7=FanNotActive,,,,,IGN:6,,,,Default,,UIR,0=FanOff;1=Minimal flow 50m³/h;2=FanMode1;3=FanMode2;4=FanMode3;5=ManualSwitch;6=MaximalFlow;7=FanNotActive,,[default:5] - min/max/step fields of enum message omitted
-w,,EWTMode,EWTMode,,,4080,18,,,UIR,0=off;1=on,,[min:0;max:1;step:1;default:0]
-r,,EWTMode,EWTMode,,,4050,18,,,UIR,0=off;1=on,,,,,IGN:6,,,,Default,,UIR,0=off;1=on,,[default:0] - min/max/step fields of enum message omitted
-w,,EWTTempMin,EWTTempMin,,,4080,19,,,SIR,10,°C,[min:0;max:100;step:5;default:50]
-r,,EWTTempMin,EWTTempMin,,,4050,19,,,SIR,10,°C,,Min,,SIR,10,°C,[min:0],Max,,SIR,10,°C,[max:100],Step,,SIR,10,°C,[step:5],Default,,SIR,10,°C,[default:50]
-w,,EWTTempMax,EWTTempMax,,,4080,1a,,,SIR,10,°C,[min:150;max:400;step:5;default:250]
-r,,EWTTempMax,EWTTempMax,,,4050,1a,,,SIR,10,°C,,Min,,SIR,10,°C,[min:150],Max,,SIR,10,°C,[max:400],Step,,SIR,10,°C,[step:5],Default,,SIR,10,°C,[default:250]
-w,,RHTSensorPresent,RHTSensorPresent,,,4080,32,,,UIR,,,[min:0;max:1;step:1;default:0]
-r,,RHTSensorPresent,RHTSensorPresent,,,4050,32,,,UIR,,,,Min,,UIR,,,[min:0],Max,,UIR,,,[max:1],Step,,UIR,,,[step:1],Default,,UIR,,,[default:0]
-w,,RHTSensorSensitivity,RHTSensorSensitivity,,,4080,33,,,SIR,,,[min:-2;max:2;step:1;default:0]
-r,,RHTSensorSensitivity,RHTSensorSensitivity,,,4050,33,,,SIR,,,,Min,,SIR,,,[min:-2],Max,,SIR,,,[max:2],Step,,SIR,,,[step:1],Default,,SIR,,,[default:0]
+w,,TemperaturePostheater,PostheaterTemp,,,4080,0b,,,SIR,10,°C,[min:150;max:300;step:5;default:210]
+r,,TemperaturePostheater,PostheaterTemp,,,4050,0b,,,SIR,10,°C,,Min,,SIR,10,°C,[min:150],Max,,SIR,10,°C,[max:300],Step,,SIR,10,°C,[step:5],Default,,SIR,10,°C,[default:210]
+w,,SelectionInput1,Input1Mode,,,4080,0c,,,UIR,0=Normally Closed;1=0-10V input;2=Normally Open;3=12V Bypass Open/0V Bypass Closed;4=0V Bypass Open/12V Bypass Closed,,[min:0;max:4;step:1;default:0]
+r,,SelectionInput1,Input1Mode,,,4050,0c,,,UIR,0=Normally Closed;1=0-10V input;2=Normally Open;3=12V Bypass Open/0V Bypass Closed;4=0V Bypass Open/12V Bypass Closed,,,,,IGN:6,,,,Default,,UIR,0=Normally Closed;1=0-10V input;2=Normally Open;3=12V Bypass Open/0V Bypass Closed;4=0V Bypass Open/12V Bypass Closed,,[default:0] - min/max/step fields of enum message omitted
+w,,MinimumVoltageInput1,Input1VMin,,,4080,0d,,,SIR,10,V,[min:0;max:100;step:5;default:0]
+r,,MinimumVoltageInput1,Input1VMin,,,4050,0d,,,SIR,10,V,,Min,,SIR,10,V,[min:0],Max,,SIR,10,V,[max:100],Step,,SIR,10,V,[step:5],Default,,SIR,10,V,[default:0]
+w,,MaximumVoltageInput1,Input1VMax,,,4080,0e,,,SIR,10,V,[min:0;max:100;step:5;default:100]
+r,,MaximumVoltageInput1,Input1VMax,,,4050,0e,,,SIR,10,V,,Min,,SIR,10,V,[min:0],Max,,SIR,10,V,[max:100],Step,,SIR,10,V,[step:5],Default,,SIR,10,V,[default:100]
+w,,ConditionsSwInput1,CN1Coupling,,,4080,0f,,,UIR,0=off;1=on;2=on if bypass open condition satisfied;3=bypass control;4=Bedroom valve,,[min:0;max:4;step:1;default:0]
+r,,ConditionsSwInput1,CN1Coupling,,,4050,0f,,,UIR,0=off;1=on;2=on if bypass open condition satisfied;3=bypass control;4=Bedroom valve,,,,,IGN:6,,,,Default,,UIR,0=off;1=on;2=on if bypass open condition satisfied;3=bypass control;4=Bedroom valve,,[default:0] - min/max/step fields of enum message omitted
+w,,SupplyFanModeSwInput1,CN1Inlet,,,4080,10,,,UIR,0=FanOff;1=Minimal flow 50m³/h;2=FanMode1;3=FanMode2;4=FanMode3;5=ManualSwitch;6=MaximalFlow;7=FanNotActive,,[min:0;max:7;step:1;default:5]
+r,,SupplyFanModeSwInput1,CN1Inlet,,,4050,10,,,UIR,0=FanOff;1=Minimal flow 50m³/h;2=FanMode1;3=FanMode2;4=FanMode3;5=ManualSwitch;6=MaximalFlow;7=FanNotActive,,,,,IGN:6,,,,Default,,UIR,0=FanOff;1=Minimal flow 50m³/h;2=FanMode1;3=FanMode2;4=FanMode3;5=ManualSwitch;6=MaximalFlow;7=FanNotActive,,[default:5] - min/max/step fields of enum message omitted
+w,,ExtractFanModeSwInput1,CN1Exhaust,,,4080,11,,,UIR,0=FanOff;1=Minimal flow 50m³/h;2=FanMode1;3=FanMode2;4=FanMode3;5=ManualSwitch;6=MaximalFlow;7=FanNotActive,,[min:0;max:7;step:1;default:5]
+r,,ExtractFanModeSwInput1,CN1Exhaust,,,4050,11,,,UIR,0=FanOff;1=Minimal flow 50m³/h;2=FanMode1;3=FanMode2;4=FanMode3;5=ManualSwitch;6=MaximalFlow;7=FanNotActive,,,,,IGN:6,,,,Default,,UIR,0=FanOff;1=Minimal flow 50m³/h;2=FanMode1;3=FanMode2;4=FanMode3;5=ManualSwitch;6=MaximalFlow;7=FanNotActive,,[default:5] - min/max/step fields of enum message omitted
+w,,SelectionInput2,Input2Mode,,,4080,12,,,UIR,0=Normally Closed;1=0-10V input;2=Normally Open;3=12V Bypass Open/0V Bypass Closed;4=0V Bypass Open/12V Bypass Closed,,[min:0;max:4;step:1;default:1]
+r,,SelectionInput2,Input2Mode,,,4050,12,,,UIR,0=Normally Closed;1=0-10V input;2=Normally Open;3=12V Bypass Open/0V Bypass Closed;4=0V Bypass Open/12V Bypass Closed,,,,,IGN:6,,,,Default,,UIR,0=Normally Closed;1=0-10V input;2=Normally Open;3=12V Bypass Open/0V Bypass Closed;4=0V Bypass Open/12V Bypass Closed,,[default:1] - min/max/step fields of enum message omitted
+w,,MinimumVoltageInput2,Input2VMin,,,4080,13,,,SIR,10,V,[min:0;max:100;step:5;default:0]
+r,,MinimumVoltageInput2,Input2VMin,,,4050,13,,,SIR,10,V,,Min,,SIR,10,V,[min:0],Max,,SIR,10,V,[max:100],Step,,SIR,10,V,[step:5],Default,,SIR,10,V,[default:0]
+w,,MaximumVoltageInput2,Input2VMax,,,4080,14,,,SIR,10,V,[min:0;max:100;step:5;default:100]
+r,,MaximumVoltageInput2,Input2VMax,,,4050,14,,,SIR,10,V,,Min,,SIR,10,V,[min:0],Max,,SIR,10,V,[max:100],Step,,SIR,10,V,[step:5],Default,,SIR,10,V,[default:100]
+w,,ConditionsSwInput2,CN2Coupling,,,4080,15,,,UIR,0=off;1=on;2=on if bypass open condition satisfied;3=bypass control;4=Bedroom valve,,[min:0;max:4;step:1;default:0]
+r,,ConditionsSwInput2,CN2Coupling,,,4050,15,,,UIR,0=off;1=on;2=on if bypass open condition satisfied;3=bypass control;4=Bedroom valve,,,,,IGN:6,,,,Default,,UIR,0=off;1=on;2=on if bypass open condition satisfied;3=bypass control;4=Bedroom valve,,[default:0] - min/max/step fields of enum message omitted
+w,,SupplyFanModeSwInput2,CN2Inlet,,,4080,16,,,UIR,0=FanOff;1=Minimal flow 50m³/h;2=FanMode1;3=FanMode2;4=FanMode3;5=ManualSwitch;6=MaximalFlow;7=FanNotActive,,[min:0;max:7;step:1;default:5]
+r,,SupplyFanModeSwInput2,CN2Inlet,,,4050,16,,,UIR,0=FanOff;1=Minimal flow 50m³/h;2=FanMode1;3=FanMode2;4=FanMode3;5=ManualSwitch;6=MaximalFlow;7=FanNotActive,,,,,IGN:6,,,,Default,,UIR,0=FanOff;1=Minimal flow 50m³/h;2=FanMode1;3=FanMode2;4=FanMode3;5=ManualSwitch;6=MaximalFlow;7=FanNotActive,,[default:5] - min/max/step fields of enum message omitted
+w,,ExtractFanModeSwInput2,CN2Exhaust,,,4080,17,,,UIR,0=FanOff;1=Minimal flow 50m³/h;2=FanMode1;3=FanMode2;4=FanMode3;5=ManualSwitch;6=MaximalFlow;7=FanNotActive,,[min:0;max:7;step:1;default:5]
+r,,ExtractFanModeSwInput2,CN2Exhaust,,,4050,17,,,UIR,0=FanOff;1=Minimal flow 50m³/h;2=FanMode1;3=FanMode2;4=FanMode3;5=ManualSwitch;6=MaximalFlow;7=FanNotActive,,,,,IGN:6,,,,Default,,UIR,0=FanOff;1=Minimal flow 50m³/h;2=FanMode1;3=FanMode2;4=FanMode3;5=ManualSwitch;6=MaximalFlow;7=FanNotActive,,[default:5] - min/max/step fields of enum message omitted
+w,,GeoHeatExchanger,EWTMode,,,4080,18,,,UIR,0=off;1=on,,[min:0;max:1;step:1;default:0]
+r,,GeoHeatExchanger,EWTMode,,,4050,18,,,UIR,0=off;1=on,,,,,IGN:6,,,,Default,,UIR,0=off;1=on,,[default:0] - min/max/step fields of enum message omitted
+w,,MinTempGeoHeatExchanger,EWTTempMin,,,4080,19,,,SIR,10,°C,[min:0;max:100;step:5;default:50]
+r,,MinTempGeoHeatExchanger,EWTTempMin,,,4050,19,,,SIR,10,°C,,Min,,SIR,10,°C,[min:0],Max,,SIR,10,°C,[max:100],Step,,SIR,10,°C,[step:5],Default,,SIR,10,°C,[default:50]
+w,,MaxTempGeoHeatExchanger,EWTTempMax,,,4080,1a,,,SIR,10,°C,[min:150;max:400;step:5;default:250]
+r,,MaxTempGeoHeatExchanger,EWTTempMax,,,4050,1a,,,SIR,10,°C,,Min,,SIR,10,°C,[min:150],Max,,SIR,10,°C,[max:400],Step,,SIR,10,°C,[step:5],Default,,SIR,10,°C,[default:250]
+w,,RHSensorPresent,RHTSensorPresent,,,4080,32,,,UIR,,,[min:0;max:1;step:1;default:0]
+r,,RHSensorPresent,RHTSensorPresent,,,4050,32,,,UIR,,,,Min,,UIR,,,[min:0],Max,,UIR,,,[max:1],Step,,UIR,,,[step:1],Default,,UIR,,,[default:0]
+w,,RHSensorSensitivity,RHTSensorSensitivity,,,4080,33,,,SIR,,,[min:-2;max:2;step:1;default:0]
+r,,RHSensorSensitivity,RHTSensorSensitivity,,,4050,33,,,SIR,,,,Min,,SIR,,,[min:-2],Max,,SIR,,,[max:2],Step,,SIR,,,[step:1],Default,,SIR,,,[default:0]
 w,,BacklightLevel,BacklightLevel,,,4080,1d,,,UIR,,%,[min:0;max:100;step:5;default:10]
 r,,BacklightLevel,BacklightLevel,,,4050,1d,,,UIR,,%,,Min,,UIR,,%,[min:0],Max,,UIR,,%,[max:100],Step,,UIR,,%,[step:5],Default,,UIR,,%,[default:10]
 w,,CO2Sensor1LowerLimit,CO2Sensor1LowerLimit,,,4080,34,,,UIR,,ppm,[min:400;max:2000;step:25;default:400]
@@ -144,8 +146,8 @@ w,,CO2SensorsActivated,CO2SensorsActivated,,,4080,3c,,,UIR,0=no;1=yes,,[min:0;ma
 r,,CO2SensorsActivated,CO2SensorsActivated,,,4050,3c,,,UIR,0=no;1=yes,,,,,IGN:6,,,,Default,,UIR,0=no;1=yes,,[default:0] - min/max/step fields of enum message omitted
 w,,FlowCorrection,FlowCorrection,,,4080,3f,,,UIR,,%,[min:90;max:110;step:1;default:100]
 r,,FlowCorrection,FlowCorrection,,,4050,3f,,,UIR,,%,,Min,,UIR,,%,[min:90],Max,,UIR,,%,[max:110],Step,,UIR,,%,[step:1],Default,,UIR,,%,[default:100]
-w,,SwitchDefaultPos,SwitchDefaultPos,,,4080,40,,,UIR,0=off;1=on,,[min:0;max:1;step:1;default:1]
-r,,SwitchDefaultPos,SwitchDefaultPos,,,4050,40,,,UIR,0=off;1=on,,,,,IGN:6,,,,Default,,UIR,0=off;1=on,,[default:1] - min/max/step fields of enum message omitted
+w,,DefaultPositionSwitch,SwitchDefaultPos,,,4080,40,,,UIR,0=off;1=on,,[min:0;max:1;step:1;default:1]
+r,,DefaultPositionSwitch,SwitchDefaultPos,,,4050,40,,,UIR,0=off;1=on,,,,,IGN:6,,,,Default,,UIR,0=off;1=on,,[default:1] - min/max/step fields of enum message omitted
 w,,FilterDaysBeforeWarning,FilterDaysBeforeWarning,,,4080,45,,,UIR,,,[min:1;max:365;step:1;default:90]
 r,,FilterDaysBeforeWarning,FilterDaysBeforeWarning,,,4050,45,,,UIR,,,,Min,,UIR,,,[min:1],Max,,UIR,,,[max:365],Step,,UIR,,,[step:1],Default,,UIR,,,[default:90]
 w,,ModbusInterface,ModbusInterface,,,4080,41,,,UIR,,,[min:0;max:3;step:2;default:1]

--- a/7c.renovent-excellent-400.csv
+++ b/7c.renovent-excellent-400.csv
@@ -1,118 +1,158 @@
-# type (r[1-9];w;u),circuit,name,[comment],[QQ],ZZ,PBSB,[ID],field1,part (m/s),datatypes/templates,divider/values,unit,comment,field2,part (m/s),datatypes/templates ,divider/values,unit,comment,field3,part (m/s),datatypes/templates,divider/values,unit,comment,field4,part (m/s),datatypes/templates,divider/values,unit,comment,field5,part (m/s),datatypes/templates,divider/values,unit,comment
-### BRINK RENOVENT EXCELLENT 300 & 400 (plus)
-##
-## This ebus config may work for Ubbink, VisionAIR, WOLF CWL series and some other systems that are identical
-## You may need to modify the 7c address in the next 2 lines for your brand/model. Or just uncomment the necessary lines.
+# type (r[1-9];w;u),circuit,name,[comment],[QQ],ZZ,PBSB,[ID],field1,part (m/s),datatypes/templates,divider/values,unit,comment,field2,part (m/s),datatypes/templates,divider/values,unit,comment,field3,part (m/s),datatypes/templates,divider/values,unit,comment,field4,part (m/s),datatypes/templates,divider/values,unit,comment,field5,part (m/s),datatypes/templates,divider/values,unit,comment
+## Diese Ebus-Konfiguration könnte für Ubbink, VisionAIR, WOLF CWL Serien, Viessmann und einige andere Systeme funktionieren, die nur umgebrandete Brink-Geräte sind
+## Quellen:
+## - Ursprüngliche Idee und einige Trennzeichen: https://github.com/dstrigl/ebusd-config-brink-renovent-excellent-300
+## - Brink Service Tool (decompiliert via Jetbrains DotPeak): https://www.brinkclimatesystems.nl/tools/software-brink-service-tool-en
+## - Renovent 150 Datenblatt: https://manuals.plus/brink/renovent-sky-150-plus-mechanical-ventilation-with-heat-recovery-manual
+## - Modbus Modul Datenblatt: https://www.brinkclimatesystems.nl/documenten/modbus-uwa2-b-uwa2-e-installation-regulations-614882.pdf
+## Nachrichtennamen basieren auf den offiziellen Übersetzungen des Brink Service Tools mit entfernten Leerzeichen und Sonderzeichen.
+## Nachrichtenkommentar ist der Name des Parameters, wie er intern im Code verwendet wird (um zu helfen, wenn die Übersetzung selbst verwirrend ist)
 
-## Renovent Excellent 400 (plus) series
-*r,kwl,,,,7c,4050,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-*w,kwl,,,,7c,4050,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+*r,Excellent400,,,,7c,
+*w,Excellent400,,,,7c,
 
-## Renovent Excellent 300 series
-## *r,kwl,,,,3c,4050,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-## *w,kwl,,,,3c,4050,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+## ALLGEMEINE HRU BEFEHLE ## (WTWCommands.cs - Einige davon sind möglicherweise nicht für dieses Gerät anwendbar, mit Vorsicht verwenden)
+w,,RücksetzenAufWerkseinstellung,FactoryReset,,,40ff,466163746f72795265736574
+w,,Fehlerliste,ResetNotifications,,,4091,,,,UIR,0x0001=Errors;0x0100=Filter;0x0101=ErrorsAndFilter;0x0000=NoResetRequested,,NoResetRequested is a dummy message doing nothing. It might be useful for integration in MQTT and HA automation.
+r,,GespeicherteFehler,RequestErrorList,,,4090,,,,HEX:18,,,
+w,,Ventilatorbetrieb,FanMode,,,40a1,,,,ULR,0x0=Holiday;0x00010001=Reduced;0x00020002=Normal;0x00030003=High,,
+r,,MaximalerDurchsatzFilter,FilterNotificationFlow,,,4050,1c,,,UIR,-1000,m³,,Min,,UIR,-1000,m³,,Max,,UIR,-1000,m³,,Step,,UIR,-1000,m³,,Default,,UIR,-1000,m³,
+r,,FilterverwendungTage,TotalFilterDays,,,4050,22,,,UIR,,Days,,Min,,UIR,,Days,,Max,,UIR,,Days,,Step,,UIR,,Days,,Default,,UIR,,Days,
+r,,Filterverwendung,TotalFilterFlow,,,4050,23,,,UIR,-1000,m³,,Min,,UIR,-1000,m³,,Max,,UIR,-1000,m³,,Step,,UIR,-1000,m³,,Default,,UIR,-1000,m³,
+r,,Betriebsdauer,TotalOperatingHours,,,4050,24,,,UIR,-5,Hours,,Min,,UIR,-5,Hours,,Max,,UIR,-5,Hours,,Step,,UIR,-5,Hours,,Default,,UIR,-5,Hours,
+r,,Gesamtdurchsatz1000m3,TotalFlow,,,4050,25,,,UIR,-1000,m³,,Min,,UIR,-1000,m³,,Max,,UIR,-1000,m³,,Step,,UIR,-1000,m³,,Default,,UIR,-1000,m³,
 
-#### AKTUELLE KONFIGDATEN ####
-r,,LuftmengeStufe0,,,,4050,21,aktuell,,UIR,,m³/h,,minimum,,UIR,,m³/h,,maximum,,UIR,,m³/h,,Schrittgroesse,,UIR,,m³/h,,Werkseinstellung,,UIR,,m³/h
-r,,LuftmengeStufe1,,,,4050,01,aktuell,,UIR,,m³/h,,minimum,,UIR,,m³/h,,maximum,,UIR,,m³/h,,Schrittgroesse,,UIR,,m³/h,,Werkseinstellung,,UIR,,m³/h
-r,,LuftmengeStufe2,,,,4050,02,aktuell,,UIR,,m³/h,,minimum,,UIR,,m³/h,,maximum,,UIR,,m³/h,,Schrittgroesse,,UIR,,m³/h,,Werkseinstellung,,UIR,,m³/h
-r,,LuftmengeStufe3,,,,4050,03,aktuell,,UIR,,m³/h,,minimum,,UIR,,m³/h,,maximum,,UIR,,m³/h,,Schrittgroesse,,UIR,,m³/h,,Werkseinstellung,,UIR,,m³/h
-r,,BypassTemperatur,,,,4050,04,aktuell,,SIR,10,°C,,minimum,,SIR,10,°C,,maximum,,SIR,10,°C,,Schrittgroesse,,SIR,10,°C,,Werkseinstellung,,SIR,10,°C
-r,,BypassHysterese,,,,4050,30,aktuell,,SIR,10,°C,,minimum,,SIR,10,°C,,maximum,,SIR,10,°C,,Schrittgroesse,,SIR,10,°C,,Werkseinstellung,,SIR,10,°C
-r,,Bypassbetrieb,,,,4050,1b,aktuell,,UIR,0=auto;1=geschlossen;2=geoeffnet,,,minimum,,UIR,,,,maximum,,UIR,,,,Schrittgroesse,,UIR,,,,Werkseinstellung,,UIR
-r,,ZentralheizungWRG,,,,4050,07,aktuell,s,UIR,0=aus;1=ein,,,minimum,,UIR,,,,maximum,,UIR,,,,Schrittgroesse,,UIR,,,,Werkseinstellung,,UIR
-r,,DruckungleichgewichtZulaessig,,,,4050,08,aktuell,s,UIR,0=nicht zulaessig;1=zulaessig,,,minimum,,UIR,,,,maximum,,UIR,,,,Schrittgroesse,,UIR,,,,Werkseinstellung,,UIR
-r,,FestesDruckungleichgewicht,,,,4050,09,aktuell,,SIR,,m³/h,,minimum,,SIR,,m³/h,,maximum,,SIR,,m³/h,,Schrittgroesse,,SIR,,m³/h,,Werkseinstellung,,SIR,,m³/h
-r,,RHSensorVorhanden,,,,4050,32,aktuell,,UIR,,,,minimum,,UIR,,,,maximum,,UIR,,,,Schrittgroesse,,UIR,,,,Werkseinstellung,,UIR,,
-r,,RHSensorEmpfindlichkeit,,,,4050,33,aktuell,,SIR,,,,minimum,,SIR,,,,maximum,,SIR,,,,Schrittgroesse,,SIR,,,,Werkseinstellung,,SIR
-r,,BeleuchtungDisplay,,,,4050,1d,aktuell,,UIR,,%,,minimum,,UIR,,%,,maximum,,UIR,,%,,Schrittgroesse,,UIR,,%,,Werkseinstellung,,UIR,,%
-r,,VorheizRegister_inst,,,,4050,31,aktuell,,UIR,1=ja;0=nein
+## Aktueller Zustand und Sensoren ##
+r,,Ventilatorbetrieb,FanMode,,,4022,01,,,UIR,0=Holiday;1=Reduced;2=Normal;3=High;4=Auto,,
+r,,Zuluftmenge,SettingInletFlow,,,4022,09,,,UIR,,m³/h,
+r,,Abluftmenge,SettingExhaustFlow,,,4022,0a,,,UIR,,m³/h,
+r,,TatsächlicheZuluftmenge,InletFlow,,,4022,0b,,,UIR,,m³/h,
+r,,TatsächlicheAbluftmenge,ExhaustFlow,,,4022,0c,,,UIR,,m³/h,
+r,,TatsächlicheDrehzahlZuluft,InletFanSpeed,,,4022,02,,,UIR,,rpm,
+r,,TatsächlicheDrehzahlAbluft,ExhaustFanSpeed,,,4022,03,,,UIR,,rpm,
+r,,PositionPerilexschalter,PerilexPosition,,,4022,05,,,UIR,0=Position_0;1=Position_1;2=Position_2;3=Position_3;,,
+r,,PositionStufenschalter,SwitchPosition,,,4022,06,,,UIR,0=Position_0;1=Position_1;2=Position_2;3=Position_3;,,
+r,,PositionSchalteingang1,Contact1Position,,,4022,1b,,,UIR,0=Off;1=On,,
+r,,PositionSchalteingang2,Contact2Position,,,4022,1c,,,UIR,0=Off;1=On,,
+r,,WertDIPSchalter,DipswitchValue,,,4022,04,,,UIR,31=Excellent180Basic;30=Excellent180Plus;7=Excellent300Basic;6=Excellent300Plus;5=Excellent400Basic;4=Excellent400Plus;27=Excellent450Basic;26=Excellent450Plus;3=RenoventElan300Basic;2=RenoventElan300Plus;19=Sky150Basic;18=Sky150Plus;9=Sky200Basic;8=Sky200Plus;21=Sky300Basic;20=Sky300Plus,,
+r,,SoftwareVersion,SoftwareVersion,,,4022,00,,,STR:13,,,
+r,,StatusBypass,BypassStatus,,,4022,0e,,,UIR,0=Initializing;1=Opening;2=Closing;3=Open;4=Closed;5=Error;6=Calibrating;255=Error,,
+r,,StromBypass,BypassCurrent,,,4022,0d,,,UIR,,,
+r,,StatusVorheizregister,PreheaterStatus,,,4022,0f,,,UIR,0=Initializing;1=Off;2=On,,
+r,,LeistungVorheizregister,PreheaterPower,,,4022,10,,,UIR,,%,
+r,,StatusNachheizregister,PostheaterStatus,,,4022,1d,,,UIR,0=Initializing;1=Off;2=On,,
+r,,LeistungNachheizregister,PostheaterPower,,,4022,1e,,,UIR,,%,
+r,,StatusErdreichwärmetauscher,EWTStatus,,,4022,1f,,,UIR,0=OpenLow;1=Closed;2=OpenHigh,,
+r,,StatusFrostschutz,FrostStatus,,,4022,16,,,UIR,0=Initializing;1=NoFrost;17=NoFrost;2=DefrostWait;3=Preheater;18=Preheater;255=Error;5=VeluHeater;6=VeluFanCtrl;7=TableFanCtrl;19=TableFanCtrl;8=Sky150Heater;9=FanCtrlFanOff;10=FanCtrlFanRestart;11=FanCtrlCurve1;12=FanCtrlCurve2;13=FanCtrlCurve3;14=FanCtrlCurve4;15=HeaterCoolDown;16=Blocked,,
+r,,StatusVentilator,FanStatus,,,4022,11,,,UIR,0=Initializing;1=ConstantFlow;2=ConstantPWM;3=Off;4=Error;5=MassBalance;6=Standby;7=ConstantRPM,,
+r,,Ablufttemperatur,InsideTemperature,,,4022,07,,,SIR,10,°C,
+r,,Außenlufttemperatur,OutsideTemperature,,,4022,08,,,SIR,10,°C,
+r,,ZusätzlicherTemperaturfühler,OptionTemperature,,,4022,1a,,,SIR,10,°C,
+r,,Filtermeldung,FilterStatus,,,4022,18,,,UIR,0=Clean;1=Dirty,,
+r,,RelativeFeuchteRHSensor,RelativeHumidity,,,4022,20,,,SIR,10,%,
+r,,FeuchtesensorStatus,HumidityBoostState,,,4022,21,,,UIR,0=Error;1=NotInitialized;2=SensorNotActive;3=PowerUpDelay;4=NormalRH;5=BoostRising;6=BoostStable;7=BoostDecending;8=BoostRHLowLevelStable,Pa,
+r,,IstwertZuluftdruck,PressureInlet,,,4022,14,,,UIR,10,Pa,
+r,,IstwertAbluftdruck,PressureExhaust,,,4022,15,,,UIR,10,Pa,
+r,,EBusSynchFehler,EBusSyncGenErrorCount,,,4022,64,,,UIR,,,
+r,,StatusCO2Sensor1,CO2Sensor1Status,,,4022,28,,,UIR,0=Error;1=NotInitialized;2=Idle;3=WarmingUp;4=Running;5=Calibrating;6=SelfTest,,
+r,,NiveauCO2Sensor1,CO2Sensor1Value,,,4022,29,,,UIR,,ppm,
+r,,StatusCO2Sensor2,CO2Sensor2Status,,,4022,2a,,,UIR,0=Error;1=NotInitialized;2=Idle;3=WarmingUp;4=Running;5=Calibrating;6=SelfTest,,
+r,,NiveauCO2Sensor2,CO2Sensor2Value,,,4022,2b,,,UIR,,ppm,
+r,,StatusCO2Sensor3,CO2Sensor3Status,,,4022,2c,,,UIR,0=Error;1=NotInitialized;2=Idle;3=WarmingUp;4=Running;5=Calibrating;6=SelfTest,,
+r,,NiveauCO2Sensor3,CO2Sensor3Value,,,4022,2d,,,UIR,,ppm,
+r,,StatusCO2Sensor4,CO2Sensor4Status,,,4022,2e,,,UIR,0=Error;1=NotInitialized;2=Idle;3=WarmingUp;4=Running;5=Calibrating;6=SelfTest,,
+r,,NiveauCO2Sensor4,CO2Sensor4Value,,,4022,2f,,,UIR,,ppm,
 
-#### FILTER UND LAUFZEITEN ####
-r,,TageMitFilter,,,,4050,22,,,UIR,,bei 90 Tagen kommt Filterwarnung 
-r,,LuftmengeMitFilter,,,,4050,23,,,UIR,,tm³ 
-r,,LuftmengeFilterSchwellwert,,,,4050,1c,,,UIR,,tm³ 
-r,,BetriebsstundenTotal,,,,4050,24,,,UIR,-5,h,,,,UIR,,,,,,UIR,,,,,,UIR,,,,,,UIR
-r,,LuftmengeTotal,,,,4050,25,,,UIR,-1000,m³,,,,UIR,,,,,,UIR,,,,,,UIR,,,,,,UIR
-
-#### KONFIGURATION AENDERN ####
-w,,LuftmengeStufe0,408001,,,4080,21,,,UIR,,m³/h
-w,,LuftmengeStufe1,408001,,,4080,01,,,UIR,,m³/h
-w,,LuftmengeStufe2,408001,,,4080,02,,,UIR,,m³/h
-w,,LuftmengeStufe3,408001,,,4080,03,,,UIR,,m³/h
-w,,BypassTemperatur,408001,,,4080,04,,,UIR,10,°C
-w,,EWTT-,408001,,,4080,19,,,UIR,10,°C
-w,,EWTT+,408001,,,4080,1A,,,UIR,10,°C
-w,,BypassHysterese,408003,,,4080,30,,,UIR,10,°C
-w,,Bypassbetrieb,408003,,,4080,1b,,,UIR,0=auto;1=geschlossen;2=geoeffnet
-w,,VorheizRegister_an,408003,,,4080,31,,,UIR,0=nein;1=ja
-w,,ZentralheizungWRG,408007,,,4080,07,,,UIR,0=aus;1=ein
-w,,DruckungleichgewichtZulaessig,408008,,,4080,08,,,UIR,0=nicht zulaessig;1=zulaessig
-w,,FestesDruckungleichgewicht,408009,,,4080,09,,,SIR,,m³/h
-w,,Ventilatorbetrieb,,,,40a1,,,,ULR,0x0=Feuchteschutz;0x00010001=Reduziert;0x00020002=Normal;0x00030003=Intensiv,,,,,IGN:1
-
-#### SENSORDATEN ####
-r,,Feuchte,40220120,,,4022,20,,,UIR,10,% ,RelativeHumidity
-r,,FeuchtigkeitsSteigerung,40220121,,,4022,21,,,UIR,0=Error;1=Not Initialized;2=Sensor Not Active;3=PowerUp Delay;4=Normal RH;5=Boost Rising;6=Boost Stable;7=Boost Decending,,HumidityBoostState
-r,,SoftwareVersion,40220100,,,4022,00,,,STR:*,,,SoftwareVersion
-r,,Ventilatorbetrieb,40220101,,,4022,01,,,UIR,0=Feuchteschutz;1=Reduziert;2=Normal;3=Intensiv,,FanMode
-r,,TatsaechlicheDrehzahlZuluft,40220102,,,4022,02,,,UIR,,rpm,InletFanSpeed
-r,,TatsaechlicheDrehzahlAbluft,40220103,,,4022,03,,,UIR,,rpm,ExhaustFanSpeed
-r,,Ablufttemperatur,40220107,,,4022,07,,,SIR,10,°C,InsideTemperature
-r,,Aussenlufttemperatur,40220108,,,4022,08,,,SIR,10,°C,OutsideTemperature
-r,,TatsaechlicheZuluftmenge,4022010B,,,4022,0b,,,UIR,,m³/h,InletFlow
-r,,TatsaechlicheAbluftmenge,4022010C,,,4022,0c,,,UIR,,m³/h,ExhaustFlow
-r,,IstwertZuluftdruck,40220114,,,4022,14,,,UIR,10,Pa,PressureInlet
-r,,IstwertAbluftdruck,40220115,,,4022,15,,,UIR,10,Pa,PressureExhaust
-r,,FilterStatus,40220118,,,4022,18,,,UIR,0=Clean;1=Dirty,,FilterStatus
-r,,CO2Sensor1Status,40220128,,,4022,28,,,UIR,,,CO2Sensor1Status
-r,,CO2Sensor1Value,40220129,,,4022,29,,,UIR,,,CO2Sensor1Value
-r,,CO2Sensor2Status,4022012A,,,4022,2a,,,UIR,,,CO2Sensor2Status
-r,,CO2Sensor2Value,4022012B,,,4022,2b,,,UIR,,,CO2Sensor2Value
-r,,CO2Sensor3Status,4022012C,,,4022,2c,,,UIR,,,CO2Sensor3Status
-r,,CO2Sensor3Value,4022012D,,,4022,2d,,,UIR,,,CO2Sensor3Value
-r,,CO2Sensor4Status,4022012E,,,4022,2e,,,UIR,,,CO2Sensor4Status
-r,,CO2Sensor4Value,4022012F,,,4022,2f,,,UIR,,,CO2Sensor4Value
-
-#### SONSTIGES ####
-r,,Errors,409000,,,4090,00,,s,UCH,,,,ign,,IGN:2,,,,code,,UCH,,,,code,,UCH,,,,code,,UCH,,,,code,,UCH,,,,code,,UCH,,,,code,,UCH,,,,code,,UCH,,,,code,,UCH,,,,code,,UCH,,,,code,,UCH
-#w,,reseterrors,409103FFFFFF,,,4091,7c0001,,m,HEX:3,,,,result,s,UIR,0=ResetNotRequested;1=ResetSuccessful;2=ResetRelayed;3=NoErrorsFound;4=ResetFailed;5=BlockingErrors;6=UnknownResult
-#w,,resetfilter,409103FFFFFF,,,4091,7c0100,,,,,,,result,s,UIR,0=ResetNotRequested;1=ResetSuccessful;2=ResetRelayed;3=FilterWarningWasNotSet;4=ResetFailed;5=UnknownResult
-r,,PosStufenschalter,,,,4022,06,,,UIR,,,switchposition
-r,,WertDIPSchalter,40220104,,,4022,04,,,UIR,,,DipswitchValue
-r,,LuefterStatus,40220111,,,4022,11,,,UIR,0=Initialize;1=Const. Flow;2=Const. RPM;3=Off;4=Error,,FanStatus
-r,,SollZuluftmenge,40220109,,,4022,09,,,UIR,,m³/h,SettingInletFlow
-r,,SollAbluftmenge,4022010A,,,4022,0a,,,UIR,,m³/h,SettingExhaustFlow
-r,,Bypassstrom,4022010D,,,4022,0D,,,UIR,,,BypassCurrent
-r,,StatusBypass,4022010E,,,4022,0E,,,UIR,0=Initialize;1=Opening;2=Closing;3=Open;4=Closed;5=Error,,BypassStatus
-r,,StatusVorheizregister,4022010F,,,4022,0F,,,UIR,0=Initialize;1=Disabled;2=Enabled,,PreheaterStatus
-r,,LeistungVorheizregister,40220110,,,4022,10,,,UIR,,,PreheaterPower
-r,,StatusNachheizregister,4022011D,,,4022,1d,,,UIR,0=Initialize;1=Disabled;2=Enabled,,PostheaterStatus
-r,,LeistungNachheizregister,4022011E,,,4022,1e,,,UIR,,,PostheaterPower
-r,,FrostStatus,40220116,,,4022,16,,,UIR,0=Initialize;1=No Frost;2=Defrost Wait;3=Heater;4=Error;5=Velu Heater;6=Velu Unbalance;7=Unbalanace,,FrostStatus
-r,,eBusSyncFehler,40220164,,,4022,64,,,UIR,,,EbusSyncGenErrorCount
-r,,PerilexPosition,40220105,,,4022,05,,,UIR,,,PerilexPosition
-r,,Contact1Position,4022011B,,,4022,1b,,,UIR,,,Contact1Position
-r,,Contact2Position,4022011C,,,4022,1c,,,UIR,,,Contact2Position
-r,,EWTStatus,4022011F,,,4022,1f,,,UIR,0=Enabled;1=Disabled,,EWTStatus
-r,,EWTT-,40500119,,,4050,19,aktuell,,SIR,10,°C,,minimum,,SIR,10,°C,,maximum,,SIR,10,°C,,Schrittgroesse,,SIR,10,°C,,Werkseinstellung,,SIR,10,°C
-r,,EWTT+,4050011A,,,4050,1A,aktuell,,SIR,10,°C,,minimum,,SIR,10,°C,,maximum,,SIR,10,°C,,Schrittgroesse,,SIR,10,°C,,Werkseinstellung,,SIR,10,°C
-r,,OptionTemperature,4022011A,,,4022,1a,,,UIR,,,OptionTemperature
-
-#### UNDEFINIERT ####
-#r,,undef_01,undef,,,,0a,,,HEX:10
-#r,,undef_02,undef,,,,0b,,,HEX:10
-#r,,undef_03,undef,,,,0c,,,HEX:10
-#r,,undef_04,undef,,,,0d,,,HEX:10
-#r,,undef_05,undef,,,,0e,,,HEX:10
-#r,,undef_06,undef,,,,0f,,,HEX:10
-#r,,undef_07,undef,,,,10,,,HEX:10
-#r,,undef_08,undef,,,,11,,,HEX:10
-#r,,undef_09,undef,,,,12,,,HEX:10
-#r,,undef_10,undef,,,,13,,,HEX:10
-#r,,undef_11,undef,,,,14,,,HEX:10
-#r,,undef_12,undef,,,,15,,,HEX:10
-#r,,undef_13,undef,,,,16,,,HEX:10
-#r,,undef_14,undef,,,,17,,,HEX:10
-#r,,undef_15,undef,,,,18,,,HEX:10
-
+## Konfigurationsparameter ## (Werte in Klammern neben dem Feld sind Definitionen dieser Feldwerte aus dem Brink Service Tool.)
+w,,LuftmengeStufe0,FlowMode0,,,4080,21,,,SIR,,m³/h,[min:0;max:50;step:50;default:50]
+r,,LuftmengeStufe0,FlowMode0,,,4050,21,,,SIR,,m³/h,,Min,,SIR,,m³/h,[min:0],Max,,SIR,,m³/h,[max:50],Step,,SIR,,m³/h,[step:50],Default,,SIR,,m³/h,[default:50]
+w,,LuftmengeStufe1,FlowMode1,,,4080,01,,,SIR,,m³/h,[min:50;max:400;step:5;default:100]
+r,,LuftmengeStufe1,FlowMode1,,,4050,01,,,SIR,,m³/h,,Min,,SIR,,m³/h,[min:50],Max,,SIR,,m³/h,[max:400],Step,,SIR,,m³/h,[step:5],Default,,SIR,,m³/h,[default:100]
+w,,LuftmengeStufe2,FlowMode2,,,4080,02,,,SIR,,m³/h,[min:50;max:400;step:5;default:200]
+r,,LuftmengeStufe2,FlowMode2,,,4050,02,,,SIR,,m³/h,,Min,,SIR,,m³/h,[min:50],Max,,SIR,,m³/h,[max:400],Step,,SIR,,m³/h,[step:5],Default,,SIR,,m³/h,[default:200]
+w,,LuftmengeStufe3,FlowMode3,,,4080,03,,,SIR,,m³/h,[min:50;max:400;step:5;default:300]
+r,,LuftmengeStufe3,FlowMode3,,,4050,03,,,SIR,,m³/h,,Min,,SIR,,m³/h,[min:50],Max,,SIR,,m³/h,[max:400],Step,,SIR,,m³/h,[step:5],Default,,SIR,,m³/h,[default:300]
+w,,BypassTemperatur,BypassTemp,,,4080,04,,,SIR,10,°C,[min:150;max:350;step:5;default:240]
+r,,BypassTemperatur,BypassTemp,,,4050,04,,,SIR,10,°C,,Min,,SIR,10,°C,[min:150],Max,,SIR,10,°C,[max:350],Step,,SIR,10,°C,[step:5],Default,,SIR,10,°C,[default:240]
+w,,BypassHysterese,BypassTempHyst,,,4080,30,,,SIR,10,°C,[min:0;max:50;step:5;default:20]
+r,,BypassHysterese,BypassTempHyst,,,4050,30,,,SIR,10,°C,,Min,,SIR,10,°C,[min:0],Max,,SIR,10,°C,[max:50],Step,,SIR,10,°C,[step:5],Default,,SIR,10,°C,[default:20]
+w,,Bypassbetrieb,BypassMode,,,4080,1b,,,UIR,0=Auto;1=Closed;2=Open,,[min:0;max:2;step:1;default:0]
+r,,Bypassbetrieb,BypassMode,,,4050,1b,,,UIR,0=Auto;1=Closed;2=Open,,,,,IGN:6,,,,Default,,UIR,0=Auto;1=Closed;2=Open,,[default:0] - min/max/step fields of enum message omitted
+w,,ZentralheizungWRG,CVWTWMode,,,4080,07,,,UIR,0=off;1=on,,[min:0;max:1;step:1;default:0]
+r,,ZentralheizungWRG,CVWTWMode,,,4050,07,,,UIR,0=off;1=on,,,,,IGN:6,,,,Default,,UIR,0=off;1=on,,[default:0] - min/max/step fields of enum message omitted
+w,,UngleichgewichtMöglich,UnbalanceMode,,,4080,08,,,UIR,0=Not Permitted;1=Permitted,,[min:0;max:1;step:1;default:1]
+r,,UngleichgewichtMöglich,UnbalanceMode,,,4050,08,,,UIR,0=Not Permitted;1=Permitted,,,,,IGN:6,,,,Default,,UIR,0=Not Permitted;1=Permitted,,[default:1] - min/max/step fields of enum message omitted
+w,,StändigesUngleichgewicht,UnbalanceFlow,,,4080,09,,,SIR,,m³/h,[min:-100;max:100;step:1;default:0]
+r,,StändigesUngleichgewicht,UnbalanceFlow,,,4050,09,,,SIR,,m³/h,,Min,,SIR,,m³/h,[min:-100],Max,,SIR,,m³/h,[max:100],Step,,SIR,,m³/h,[step:1],Default,,SIR,,m³/h,[default:0]
+w,,TypZusätslichesHeizregister,ExtraHeaterType,,,4080,0a,,,UIR,,,[min:0;max:2;step:1;default:0]
+r,,TypZusätslichesHeizregister,ExtraHeaterType,,,4050,0a,,,UIR,,,,Min,,UIR,,,[min:0],Max,,UIR,,,[max:2],Step,,UIR,,,[step:1],Default,,UIR,,,[default:0]
+w,,TemperaturNachheizregister,PostheaterTemp,,,4080,0b,,,SIR,10,°C,[min:150;max:300;step:5;default:210]
+r,,TemperaturNachheizregister,PostheaterTemp,,,4050,0b,,,SIR,10,°C,,Min,,SIR,10,°C,[min:150],Max,,SIR,10,°C,[max:300],Step,,SIR,10,°C,[step:5],Default,,SIR,10,°C,[default:210]
+w,,AuswahlEingang1,Input1Mode,,,4080,0c,,,UIR,0=Normally Closed;1=0-10V input;2=Normally Open;3=12V Bypass Open/0V Bypass Closed;4=0V Bypass Open/12V Bypass Closed,,[min:0;max:4;step:1;default:0]
+r,,AuswahlEingang1,Input1Mode,,,4050,0c,,,UIR,0=Normally Closed;1=0-10V input;2=Normally Open;3=12V Bypass Open/0V Bypass Closed;4=0V Bypass Open/12V Bypass Closed,,,,,IGN:6,,,,Default,,UIR,0=Normally Closed;1=0-10V input;2=Normally Open;3=12V Bypass Open/0V Bypass Closed;4=0V Bypass Open/12V Bypass Closed,,[default:0] - min/max/step fields of enum message omitted
+w,,MinimaleSpannungEingang1,Input1VMin,,,4080,0d,,,SIR,10,V,[min:0;max:100;step:5;default:0]
+r,,MinimaleSpannungEingang1,Input1VMin,,,4050,0d,,,SIR,10,V,,Min,,SIR,10,V,[min:0],Max,,SIR,10,V,[max:100],Step,,SIR,10,V,[step:5],Default,,SIR,10,V,[default:0]
+w,,MaximaleSpannungEingang1,Input1VMax,,,4080,0e,,,SIR,10,V,[min:0;max:100;step:5;default:100]
+r,,MaximaleSpannungEingang1,Input1VMax,,,4050,0e,,,SIR,10,V,,Min,,SIR,10,V,[min:0],Max,,SIR,10,V,[max:100],Step,,SIR,10,V,[step:5],Default,,SIR,10,V,[default:100]
+w,,BedingungenSchalteingang1,CN1Coupling,,,4080,0f,,,UIR,0=off;1=on;2=on if bypass open condition satisfied;3=bypass control;4=Bedroom valve,,[min:0;max:4;step:1;default:0]
+r,,BedingungenSchalteingang1,CN1Coupling,,,4050,0f,,,UIR,0=off;1=on;2=on if bypass open condition satisfied;3=bypass control;4=Bedroom valve,,,,,IGN:6,,,,Default,,UIR,0=off;1=on;2=on if bypass open condition satisfied;3=bypass control;4=Bedroom valve,,[default:0] - min/max/step fields of enum message omitted
+w,,FunktionZuluftventilatorEingang1,CN1Inlet,,,4080,10,,,UIR,0=FanOff;1=Minimal flow 50m³/h;2=FanMode1;3=FanMode2;4=FanMode3;5=ManualSwitch;6=MaximalFlow;7=FanNotActive,,[min:0;max:7;step:1;default:5]
+r,,FunktionZuluftventilatorEingang1,CN1Inlet,,,4050,10,,,UIR,0=FanOff;1=Minimal flow 50m³/h;2=FanMode1;3=FanMode2;4=FanMode3;5=ManualSwitch;6=MaximalFlow;7=FanNotActive,,,,,IGN:6,,,,Default,,UIR,0=FanOff;1=Minimal flow 50m³/h;2=FanMode1;3=FanMode2;4=FanMode3;5=ManualSwitch;6=MaximalFlow;7=FanNotActive,,[default:5] - min/max/step fields of enum message omitted
+w,,FunktionAbluftventilatorEingang1,CN1Exhaust,,,4080,11,,,UIR,0=FanOff;1=Minimal flow 50m³/h;2=FanMode1;3=FanMode2;4=FanMode3;5=ManualSwitch;6=MaximalFlow;7=FanNotActive,,[min:0;max:7;step:1;default:5]
+r,,FunktionAbluftventilatorEingang1,CN1Exhaust,,,4050,11,,,UIR,0=FanOff;1=Minimal flow 50m³/h;2=FanMode1;3=FanMode2;4=FanMode3;5=ManualSwitch;6=MaximalFlow;7=FanNotActive,,,,,IGN:6,,,,Default,,UIR,0=FanOff;1=Minimal flow 50m³/h;2=FanMode1;3=FanMode2;4=FanMode3;5=ManualSwitch;6=MaximalFlow;7=FanNotActive,,[default:5] - min/max/step fields of enum message omitted
+w,,AuswahlEingang2,Input2Mode,,,4080,12,,,UIR,0=Normally Closed;1=0-10V input;2=Normally Open;3=12V Bypass Open/0V Bypass Closed;4=0V Bypass Open/12V Bypass Closed,,[min:0;max:4;step:1;default:1]
+r,,AuswahlEingang2,Input2Mode,,,4050,12,,,UIR,0=Normally Closed;1=0-10V input;2=Normally Open;3=12V Bypass Open/0V Bypass Closed;4=0V Bypass Open/12V Bypass Closed,,,,,IGN:6,,,,Default,,UIR,0=Normally Closed;1=0-10V input;2=Normally Open;3=12V Bypass Open/0V Bypass Closed;4=0V Bypass Open/12V Bypass Closed,,[default:1] - min/max/step fields of enum message omitted
+w,,MinimaleSpannungEingang2,Input2VMin,,,4080,13,,,SIR,10,V,[min:0;max:100;step:5;default:0]
+r,,MinimaleSpannungEingang2,Input2VMin,,,4050,13,,,SIR,10,V,,Min,,SIR,10,V,[min:0],Max,,SIR,10,V,[max:100],Step,,SIR,10,V,[step:5],Default,,SIR,10,V,[default:0]
+w,,MaximaleSpannungEingang2,Input2VMax,,,4080,14,,,SIR,10,V,[min:0;max:100;step:5;default:100]
+r,,MaximaleSpannungEingang2,Input2VMax,,,4050,14,,,SIR,10,V,,Min,,SIR,10,V,[min:0],Max,,SIR,10,V,[max:100],Step,,SIR,10,V,[step:5],Default,,SIR,10,V,[default:100]
+w,,BedingungenSchalteingang2,CN2Coupling,,,4080,15,,,UIR,0=off;1=on;2=on if bypass open condition satisfied;3=bypass control;4=Bedroom valve,,[min:0;max:4;step:1;default:0]
+r,,BedingungenSchalteingang2,CN2Coupling,,,4050,15,,,UIR,0=off;1=on;2=on if bypass open condition satisfied;3=bypass control;4=Bedroom valve,,,,,IGN:6,,,,Default,,UIR,0=off;1=on;2=on if bypass open condition satisfied;3=bypass control;4=Bedroom valve,,[default:0] - min/max/step fields of enum message omitted
+w,,FunktionZuluftventilatorEingang2,CN2Inlet,,,4080,16,,,UIR,0=FanOff;1=Minimal flow 50m³/h;2=FanMode1;3=FanMode2;4=FanMode3;5=ManualSwitch;6=MaximalFlow;7=FanNotActive,,[min:0;max:7;step:1;default:5]
+r,,FunktionZuluftventilatorEingang2,CN2Inlet,,,4050,16,,,UIR,0=FanOff;1=Minimal flow 50m³/h;2=FanMode1;3=FanMode2;4=FanMode3;5=ManualSwitch;6=MaximalFlow;7=FanNotActive,,,,,IGN:6,,,,Default,,UIR,0=FanOff;1=Minimal flow 50m³/h;2=FanMode1;3=FanMode2;4=FanMode3;5=ManualSwitch;6=MaximalFlow;7=FanNotActive,,[default:5] - min/max/step fields of enum message omitted
+w,,FunktionAbluftventilatorEingang2,CN2Exhaust,,,4080,17,,,UIR,0=FanOff;1=Minimal flow 50m³/h;2=FanMode1;3=FanMode2;4=FanMode3;5=ManualSwitch;6=MaximalFlow;7=FanNotActive,,[min:0;max:7;step:1;default:5]
+r,,FunktionAbluftventilatorEingang2,CN2Exhaust,,,4050,17,,,UIR,0=FanOff;1=Minimal flow 50m³/h;2=FanMode1;3=FanMode2;4=FanMode3;5=ManualSwitch;6=MaximalFlow;7=FanNotActive,,,,,IGN:6,,,,Default,,UIR,0=FanOff;1=Minimal flow 50m³/h;2=FanMode1;3=FanMode2;4=FanMode3;5=ManualSwitch;6=MaximalFlow;7=FanNotActive,,[default:5] - min/max/step fields of enum message omitted
+w,,Erdreichwärmetauscher,EWTMode,,,4080,18,,,UIR,0=off;1=on,,[min:0;max:1;step:1;default:0]
+r,,Erdreichwärmetauscher,EWTMode,,,4050,18,,,UIR,0=off;1=on,,,,,IGN:6,,,,Default,,UIR,0=off;1=on,,[default:0] - min/max/step fields of enum message omitted
+w,,MinTempErdreichwärmetauscher,EWTTempMin,,,4080,19,,,SIR,10,°C,[min:0;max:100;step:5;default:50]
+r,,MinTempErdreichwärmetauscher,EWTTempMin,,,4050,19,,,SIR,10,°C,,Min,,SIR,10,°C,[min:0],Max,,SIR,10,°C,[max:100],Step,,SIR,10,°C,[step:5],Default,,SIR,10,°C,[default:50]
+w,,MaxTempErdreichwärmetauscher,EWTTempMax,,,4080,1a,,,SIR,10,°C,[min:150;max:400;step:5;default:250]
+r,,MaxTempErdreichwärmetauscher,EWTTempMax,,,4050,1a,,,SIR,10,°C,,Min,,SIR,10,°C,[min:150],Max,,SIR,10,°C,[max:400],Step,,SIR,10,°C,[step:5],Default,,SIR,10,°C,[default:250]
+w,,FeuchtesensorVorhanden,RHTSensorPresent,,,4080,32,,,UIR,,,[min:0;max:1;step:1;default:0]
+r,,FeuchtesensorVorhanden,RHTSensorPresent,,,4050,32,,,UIR,,,,Min,,UIR,,,[min:0],Max,,UIR,,,[max:1],Step,,UIR,,,[step:1],Default,,UIR,,,[default:0]
+w,,EmpfindlichkeitFeuchtesensor,RHTSensorSensitivity,,,4080,33,,,SIR,,,[min:-2;max:2;step:1;default:0]
+r,,EmpfindlichkeitFeuchtesensor,RHTSensorSensitivity,,,4050,33,,,SIR,,,,Min,,SIR,,,[min:-2],Max,,SIR,,,[max:2],Step,,SIR,,,[step:1],Default,,SIR,,,[default:0]
+w,,BeleuchtungDisplay,BacklightLevel,,,4080,1d,,,UIR,,%,[min:0;max:100;step:5;default:10]
+r,,BeleuchtungDisplay,BacklightLevel,,,4050,1d,,,UIR,,%,,Min,,UIR,,%,[min:0],Max,,UIR,,%,[max:100],Step,,UIR,,%,[step:5],Default,,UIR,,%,[default:10]
+w,,CO2Sensor1UntererGrenzwert,CO2Sensor1LowerLimit,,,4080,34,,,UIR,,ppm,[min:400;max:2000;step:25;default:400]
+r,,CO2Sensor1UntererGrenzwert,CO2Sensor1LowerLimit,,,4050,34,,,UIR,,ppm,,Min,,UIR,,ppm,[min:400],Max,,UIR,,ppm,[max:2000],Step,,UIR,,ppm,[step:25],Default,,UIR,,ppm,[default:400]
+w,,CO2Sensor1ObererGrenzwert,CO2Sensor1UpperLimit,,,4080,35,,,UIR,,ppm,[min:400;max:2000;step:25;default:1200]
+r,,CO2Sensor1ObererGrenzwert,CO2Sensor1UpperLimit,,,4050,35,,,UIR,,ppm,,Min,,UIR,,ppm,[min:400],Max,,UIR,,ppm,[max:2000],Step,,UIR,,ppm,[step:25],Default,,UIR,,ppm,[default:1200]
+w,,CO2Sensor2UntererGrenzwert,CO2Sensor2LowerLimit,,,4080,36,,,UIR,,ppm,[min:400;max:2000;step:25;default:400]
+r,,CO2Sensor2UntererGrenzwert,CO2Sensor2LowerLimit,,,4050,36,,,UIR,,ppm,,Min,,UIR,,ppm,[min:400],Max,,UIR,,ppm,[max:2000],Step,,UIR,,ppm,[step:25],Default,,UIR,,ppm,[default:400]
+w,,CO2Sensor2ObererGrenzwert,CO2Sensor2UpperLimit,,,4080,37,,,UIR,,ppm,[min:400;max:2000;step:25;default:1200]
+r,,CO2Sensor2ObererGrenzwert,CO2Sensor2UpperLimit,,,4050,37,,,UIR,,ppm,,Min,,UIR,,ppm,[min:400],Max,,UIR,,ppm,[max:2000],Step,,UIR,,ppm,[step:25],Default,,UIR,,ppm,[default:1200]
+w,,CO2Sensor3UntererGrenzwert,CO2Sensor3LowerLimit,,,4080,38,,,UIR,,ppm,[min:400;max:2000;step:25;default:400]
+r,,CO2Sensor3UntererGrenzwert,CO2Sensor3LowerLimit,,,4050,38,,,UIR,,ppm,,Min,,UIR,,ppm,[min:400],Max,,UIR,,ppm,[max:2000],Step,,UIR,,ppm,[step:25],Default,,UIR,,ppm,[default:400]
+w,,CO2Sensor3ObererGrenzwert,CO2Sensor3UpperLimit,,,4080,39,,,UIR,,ppm,[min:400;max:2000;step:25;default:1200]
+r,,CO2Sensor3ObererGrenzwert,CO2Sensor3UpperLimit,,,4050,39,,,UIR,,ppm,,Min,,UIR,,ppm,[min:400],Max,,UIR,,ppm,[max:2000],Step,,UIR,,ppm,[step:25],Default,,UIR,,ppm,[default:1200]
+w,,CO2Sensor4UntererGrenzwert,CO2Sensor4LowerLimit,,,4080,3a,,,UIR,,ppm,[min:400;max:2000;step:25;default:400]
+r,,CO2Sensor4UntererGrenzwert,CO2Sensor4LowerLimit,,,4050,3a,,,UIR,,ppm,,Min,,UIR,,ppm,[min:400],Max,,UIR,,ppm,[max:2000],Step,,UIR,,ppm,[step:25],Default,,UIR,,ppm,[default:400]
+w,,CO2Sensor4ObererGrenzwert,CO2Sensor4UpperLimit,,,4080,3b,,,UIR,,ppm,[min:400;max:2000;step:25;default:1200]
+r,,CO2Sensor4ObererGrenzwert,CO2Sensor4UpperLimit,,,4050,3b,,,UIR,,ppm,,Min,,UIR,,ppm,[min:400],Max,,UIR,,ppm,[max:2000],Step,,UIR,,ppm,[step:25],Default,,UIR,,ppm,[default:1200]
+w,,CO2SensorenAktiviert,CO2SensorsActivated,,,4080,3c,,,UIR,0=no;1=yes,,[min:0;max:1;step:1;default:0]
+r,,CO2SensorenAktiviert,CO2SensorsActivated,,,4050,3c,,,UIR,0=no;1=yes,,,,,IGN:6,,,,Default,,UIR,0=no;1=yes,,[default:0] - min/max/step fields of enum message omitted
+w,,Durchsatzkorrektur,FlowCorrection,,,4080,3f,,,UIR,,%,[min:90;max:110;step:1;default:100]
+r,,Durchsatzkorrektur,FlowCorrection,,,4050,3f,,,UIR,,%,,Min,,UIR,,%,[min:90],Max,,UIR,,%,[max:110],Step,,UIR,,%,[step:1],Default,,UIR,,%,[default:100]
+w,,Schaltergrundstellung,SwitchDefaultPos,,,4080,40,,,UIR,0=off;1=on,,[min:0;max:1;step:1;default:1]
+r,,Schaltergrundstellung,SwitchDefaultPos,,,4050,40,,,UIR,0=off;1=on,,,,,IGN:6,,,,Default,,UIR,0=off;1=on,,[default:1] - min/max/step fields of enum message omitted
+w,,TageVorFilterwarnung,FilterDaysBeforeWarning,,,4080,45,,,UIR,,,[min:1;max:365;step:1;default:90]
+r,,TageVorFilterwarnung,FilterDaysBeforeWarning,,,4050,45,,,UIR,,,,Min,,UIR,,,[min:1],Max,,UIR,,,[max:365],Step,,UIR,,,[step:1],Default,,UIR,,,[default:90]
+w,,SchnittstelleModbus,ModbusInterface,,,4080,41,,,UIR,,,[min:0;max:3;step:2;default:1]
+r,,SchnittstelleModbus,ModbusInterface,,,4050,41,,,UIR,,,,Min,,UIR,,,[min:0],Max,,UIR,,,[max:3],Step,,UIR,,,[step:2],Default,,UIR,,,[default:1]
+w,,AdresseModbusSlave,ModbusSlaveAddress,,,4080,42,,,UIR,,,[min:1;max:247;step:1;default:11]
+r,,AdresseModbusSlave,ModbusSlaveAddress,,,4050,42,,,UIR,,,,Min,,UIR,,,[min:1],Max,,UIR,,,[max:247],Step,,UIR,,,[step:1],Default,,UIR,,,[default:11]
+w,,GeschwindigkeitModbus,ModbusSpeed,,,4080,43,,,UIR,0=1200 Baud;1=2400 Baud;2=4800 Baud;3=9600 Baud;4=19k2 Baud;5=38k4 Baud;6=56k Baud;7=115k Baud,,[min:0;max:7;step:1;default:3]
+r,,GeschwindigkeitModbus,ModbusSpeed,,,4050,43,,,UIR,0=1200 Baud;1=2400 Baud;2=4800 Baud;3=9600 Baud;4=19k2 Baud;5=38k4 Baud;6=56k Baud;7=115k Baud,,,,,IGN:6,,,,Default,,UIR,0=1200 Baud;1=2400 Baud;2=4800 Baud;3=9600 Baud;4=19k2 Baud;5=38k4 Baud;6=56k Baud;7=115k Baud,,[default:3] - min/max/step fields of enum message omitted
+w,,ParitätModbus,ModbusParity,,,4080,44,,,UIR,0=No Parity;1=Even Parity;2=Odd Parity;3=Unknown,,[min:0;max:3;step:1;default:1]
+r,,ParitätModbus,ModbusParity,,,4050,44,,,UIR,0=No Parity;1=Even Parity;2=Odd Parity;3=Unknown,,,,,IGN:6,,,,Default,,UIR,0=No Parity;1=Even Parity;2=Odd Parity;3=Unknown,,[default:1] - min/max/step fields of enum message omitted


### PR DESCRIPTION
Given the warm acceptance of my last PR, I figured out the bit of extra effort to get even German translation of my latest file might be appreciated, so here it is. Note, that  some parameter names changed for English as well, since I opted to use the names shown in the UI to the user, rather than the internal variable names, which was my original approach. In case this woudl be appreciated - in my repo, I have other language mutations of the files - French, Spanish, Italian, Dutch and Polish. I would be happy to share them here as well, since it seems this repo is a 'go-to' place for integrating Brink vetilation units to Home Assistant.

Future Work:
- use the UI names even for enum values and translate those as well.
 